### PR TITLE
[no ticket ] Fix client library's security schema issue and local runner script config

### DIFF
--- a/local-dev/run_local.sh
+++ b/local-dev/run_local.sh
@@ -13,5 +13,6 @@ export BUFFER_CRL_TESTING_MODE=true
 export BUFFER_CRL_JANITOR_CLIENT_CREDENTIAL_FILE_PATH="$(dirname $0)"/../src/test/resources/rendered/janitor-client-sa-account.json
 export BUFFER_CRL_JANITOR_TRACK_RESOURCE_PROJECT_ID=terra-kernel-k8s
 export BUFFER_CRL_JANITOR_TRACK_RESOURCE_TOPIC_ID=crljanitor-tools-pubsub-topic
+export BUFFER_POOL_CONFIG_PATH=config/toolsalpha
 
 ./gradlew bootRun

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -9,11 +9,8 @@ servers:
   - url: /
 
 security:
-  - googleoauth:
-      - openid
-      - email
-      - profile
   - bearerAuth: []
+  - authorization: [openid, email, profile]
 
 paths:
   '/status':


### PR DESCRIPTION
Initially we mix use `googleoauth` with `authroization` in request header