### PR TITLE
[PF-254]: Move handout request id into requestBody for put operation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
     group = 'bio.terra'
-    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.0.1-SNAPSHOT'
+    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.4.1-SNAPSHOT'
     ext {
         artifactGroup = "${group}.buffer"
         swaggerOutputDir = "${buildDir}/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
     group = 'bio.terra'
-    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.4.1-SNAPSHOT'
+    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.0.1-SNAPSHOT'
     ext {
         artifactGroup = "${group}.buffer"
         swaggerOutputDir = "${buildDir}/generated"

--- a/src/main/java/bio/terra/buffer/app/controller/BufferApiController.java
+++ b/src/main/java/bio/terra/buffer/app/controller/BufferApiController.java
@@ -4,6 +4,7 @@ import bio.terra.buffer.app.configuration.BufferJdbcConfiguration;
 import bio.terra.buffer.common.PoolId;
 import bio.terra.buffer.common.RequestHandoutId;
 import bio.terra.buffer.generated.controller.BufferApi;
+import bio.terra.buffer.generated.model.HandoutRequestBody;
 import bio.terra.buffer.generated.model.PoolInfo;
 import bio.terra.buffer.generated.model.ResourceInfo;
 import bio.terra.buffer.service.pool.PoolService;
@@ -34,10 +35,12 @@ public class BufferApiController implements BufferApi {
   }
 
   @Override
-  public ResponseEntity<ResourceInfo> handoutResource(String poolId, String handoutRequestId) {
+  public ResponseEntity<ResourceInfo> handoutResource(
+      String poolId, HandoutRequestBody handoutRequestBody) {
     return new ResponseEntity<>(
         poolService.handoutResource(
-            PoolId.create(poolId), RequestHandoutId.create(handoutRequestId)),
+            PoolId.create(poolId),
+            RequestHandoutId.create(handoutRequestBody.getHandoutRequestId())),
         HttpStatus.OK);
   }
 

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -36,6 +36,9 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PoolId'
         - $ref: '#/components/parameters/HandoutRequestId'
+      requestBody:
+        required: false
+        content: {}
       tags:
         - buffer
       responses:

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -29,16 +29,18 @@ paths:
           description: Service is broken
           $ref: '#/components/responses/StatusResponse'
 
-  '/api/pool/v1/{poolId}/resource/{handoutRequestId}':
+  '/api/pool/v1/{poolId}/resource':
     put:
       summary: Get a resource from pool and update the resource state, each handoutRequestId is assigned to the resource no more than once. Using the same handoutRequestId will get the same ResourceInfo
       operationId: handoutResource
       parameters:
         - $ref: '#/components/parameters/PoolId'
-        - $ref: '#/components/parameters/HandoutRequestId'
       requestBody:
-        required: false
-        content: {}
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/parameters/HandoutRequestId'
       tags:
         - buffer
       responses:
@@ -92,16 +94,6 @@ components:
       schema:
         type: string
 
-    HandoutRequestId:
-      name: handoutRequestId
-      in: path
-      description: |-
-        The unique identifier presented by the client for a resource request.
-        Using the same handoutRequestId in the same pool would ge the same resource back.
-      required: true
-      schema:
-        type: string
-
   schemas:
     ErrorReport:
       type: object
@@ -132,6 +124,12 @@ components:
                 type: array
                 items:
                   type: string
+
+    HandoutRequestId:
+      description: |-
+        The unique identifier presented by the client for a resource request.
+        Using the same handoutRequestId in the same pool would ge the same resource back.
+      type: string
 
     PoolConfigs:
       description: |-

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -40,7 +40,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/parameters/HandoutRequestId'
+              $ref: '#/components/schemas/HandoutRequestBody'
       tags:
         - buffer
       responses:
@@ -125,11 +125,18 @@ components:
                 items:
                   type: string
 
-    HandoutRequestId:
+    HandoutRequestBody:
       description: |-
-        The unique identifier presented by the client for a resource request.
-        Using the same handoutRequestId in the same pool would ge the same resource back.
-      type: string
+        The request body for getting resource from Buffer Service
+      type: object
+      required:
+        - handoutRequestId
+      properties:
+        handoutRequestId:
+          description: |-
+            The unique identifier presented by the client for a resource request.
+            Using the same handoutRequestId in the same pool would ge the same resource back.
+          type: string
 
     PoolConfigs:
       description: |-

--- a/src/test/java/bio/terra/buffer/app/controller/BufferApiControllerTest.java
+++ b/src/test/java/bio/terra/buffer/app/controller/BufferApiControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -66,7 +67,10 @@ public class BufferApiControllerTest {
 
     String response =
         this.mvc
-            .perform(put("/api/pool/v1/" + poolId.id() + "/resource/" + requestHandoutId.id()))
+            .perform(
+                put("/api/pool/v1/" + poolId.id() + "/resource")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestHandoutId.id()))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -96,14 +100,20 @@ public class BufferApiControllerTest {
                 .build()));
 
     this.mvc
-        .perform(put("/api/pool/v1/poolId/resource/handoutRequestId"))
+        .perform(
+            put("/api/pool/v1/poolId/resource")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("handoutRequestId"))
         .andExpect(status().isNotFound());
   }
 
   @Test
   public void handoutResource_invalidPoolId() throws Exception {
     this.mvc
-        .perform(put("/api/pool/v1/poolId/resource/handoutRequestId"))
+        .perform(
+            put("/api/pool/v1/poolId/resource")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("handoutRequestId"))
         .andExpect(status().isBadRequest());
   }
 

--- a/src/test/java/bio/terra/buffer/app/controller/BufferApiControllerTest.java
+++ b/src/test/java/bio/terra/buffer/app/controller/BufferApiControllerTest.java
@@ -70,7 +70,9 @@ public class BufferApiControllerTest {
             .perform(
                 put("/api/pool/v1/" + poolId.id() + "/resource")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestHandoutId.id()))
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new HandoutRequestBody().handoutRequestId(requestHandoutId.id()))))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -103,7 +105,9 @@ public class BufferApiControllerTest {
         .perform(
             put("/api/pool/v1/poolId/resource")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("handoutRequestId"))
+                .content(
+                    objectMapper.writeValueAsString(
+                        new HandoutRequestBody().handoutRequestId("handoutRequestId"))))
         .andExpect(status().isNotFound());
   }
 
@@ -113,7 +117,9 @@ public class BufferApiControllerTest {
         .perform(
             put("/api/pool/v1/poolId/resource")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("handoutRequestId"))
+                .content(
+                    objectMapper.writeValueAsString(
+                        new HandoutRequestBody().handoutRequestId("handoutRequestId"))))
         .andExpect(status().isBadRequest());
   }
 


### PR DESCRIPTION
Similar to what TDR did: https://github.com/DataBiosphere/jade-data-repo/pull/631
Body can not be null for jersey2 client library