### PR TITLE
[PF-287] Improve Stairway setup in Buffer service

### DIFF
--- a/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
@@ -29,9 +29,6 @@ public class PrimaryConfiguration {
    */
   private int resourceDeletionPerPoolLimit = 50;
 
-  /** How often to record the counts of the different resources in the database. */
-  private Duration recordResourceCountPeriod = Duration.ofMinutes(10);
-
   public boolean isSchedulerEnabled() {
     return schedulerEnabled;
   }

--- a/src/main/java/bio/terra/buffer/service/stairway/StairwayComponent.java
+++ b/src/main/java/bio/terra/buffer/service/stairway/StairwayComponent.java
@@ -48,6 +48,7 @@ public class StairwayComponent {
         Stairway.newBuilder()
             .maxParallelFlights(stairwayConfiguration.getMaxParallelFlights())
             .applicationContext(applicationContext)
+            .keepFlightLog(true)
             .stairwayName(stairwayConfiguration.getName())
             .stairwayClusterName(stairwayConfiguration.getClusterName());
     try {

--- a/src/main/java/bio/terra/buffer/service/stairway/StairwayComponent.java
+++ b/src/main/java/bio/terra/buffer/service/stairway/StairwayComponent.java
@@ -44,6 +44,7 @@ public class StairwayComponent {
         stairwayConfiguration.getClusterName(),
         stairwayConfiguration.getClusterName());
     // TODO(PF-161): Configure the workqueue pubsub subscription and topic for multi-instance.
+    // TODO(PF-314): Cleanup old flightlogs.
     Stairway.Builder builder =
         Stairway.newBuilder()
             .maxParallelFlights(stairwayConfiguration.getMaxParallelFlights())
@@ -67,7 +68,7 @@ public class StairwayComponent {
           stairwayConfiguration.isForceCleanStart(),
           stairwayConfiguration.isMigrateUpgrade());
       // (PF-161): Get obsolete Stairway instances from k8s for multi-instance stairway.
-      stairway.recoverAndStart(ImmutableList.of());
+      stairway.recoverAndStart(ImmutableList.of(stairwayConfiguration.getName()));
     } catch (StairwayException | InterruptedException e) {
       status = Status.ERROR;
       throw new RuntimeException("Error starting Stairway", e);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,11 @@ buffer:
       uri: jdbc:postgresql://127.0.0.1:5432/${BUFFER_STAIRWAY_DATABASE_NAME}
       username:
     force-clean-start: false
-    max-parallel-flights: 80
+    # This decides how soon we can fill a pool. Example: if total pools size is 3000 and each flight takes 10 minues.
+    # having 500 hears means it takes 3000 resources / 500 threads * 10minute = 60 minutes to create this pool
+    max-parallel-flights: 500
     migrate-upgrade: true
+    name: buffer-stairway
     quiet-down-timeout: 20s
     terminate-timeout: 5s
 


### PR DESCRIPTION
Background: Each project creation is a flight and it block a thread for 10~15 minutes. We need more threads to be able to fill the pool sooner.
Things in the PR:
1.  Set stairway name - because without the name every-time we restart Buffer server it will create a new stairway name, and we can not recover the previous one. 
2. Add more threads for stairway - We need more threads to make is faster to fill a pool. 
3. Don't swipe flight log when flight finished - Flightlog is useful for debug purpose. 