### PR TITLE
[no ticket] Use String not uuid when storing value into Stairway

### DIFF
--- a/src/main/java/bio/terra/buffer/common/ResourceId.java
+++ b/src/main/java/bio/terra/buffer/common/ResourceId.java
@@ -22,6 +22,7 @@ public abstract class ResourceId {
 
   /** Retrieve and construct a ResourceId form {@link FlightMap}. */
   public static ResourceId retrieve(FlightMap map) {
+    // TODO(PF-316): Store UUID in flight map PF-316 after fixed
     return ResourceId.create(UUID.fromString(map.get(RESOURCE_ID_MAP_KEY, String.class)));
   }
 

--- a/src/main/java/bio/terra/buffer/common/ResourceId.java
+++ b/src/main/java/bio/terra/buffer/common/ResourceId.java
@@ -22,11 +22,11 @@ public abstract class ResourceId {
 
   /** Retrieve and construct a ResourceId form {@link FlightMap}. */
   public static ResourceId retrieve(FlightMap map) {
-    return ResourceId.create(map.get(RESOURCE_ID_MAP_KEY, UUID.class));
+    return ResourceId.create(UUID.fromString(map.get(RESOURCE_ID_MAP_KEY, String.class)));
   }
 
   /** Stores ResourceId value in {@link FlightMap}. */
   public void store(FlightMap map) {
-    map.put(RESOURCE_ID_MAP_KEY, id());
+    map.put(RESOURCE_ID_MAP_KEY, id().toString());
   }
 }


### PR DESCRIPTION
Found a bug in Stairway  https://broadworkbench.atlassian.net/browse/PF-316
After Stariway put value into Stairway db then retrieve it from db, seems it loses initial object type. 
So I have this work-around that stores String as raw type, and let Buffer Code to serialize/deserialize