### PR TITLE
[no ticket] Use the created quota projects as quota project

### DIFF
--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -230,7 +230,7 @@ public class CrlConfiguration {
     return httpRequest -> {
       requestInitializer.initialize(httpRequest);
       httpRequest.setConnectTimeout(5 * 60000); // 5 minutes connect timeout
-      httpRequest.setReadTimeout(5 * 60000); // 5 minutes read timeout
+      httpRequest.setReadTimeout(5 * 60000); // 5 minutes read timeoutminutes read timeout
     };
   }
 }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/EnableServicesStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/EnableServicesStep.java
@@ -1,10 +1,12 @@
 package bio.terra.buffer.service.resource.flight;
 
+import static bio.terra.buffer.app.configuration.CrlConfiguration.CLIENT_NAME;
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
-import static bio.terra.buffer.service.resource.flight.GoogleUtils.pollUntilSuccess;
-import static bio.terra.buffer.service.resource.flight.GoogleUtils.projectIdToName;
+import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
+import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.google.api.services.common.Defaults;
 import bio.terra.cloudres.google.api.services.common.OperationCow;
 import bio.terra.cloudres.google.serviceusage.ServiceUsageCow;
 import bio.terra.stairway.FlightContext;
@@ -12,8 +14,14 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.services.compute.ComputeScopes;
+import com.google.api.services.serviceusage.v1.ServiceUsage;
 import com.google.api.services.serviceusage.v1.model.BatchEnableServicesRequest;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,22 +29,36 @@ import org.slf4j.LoggerFactory;
 /** Enable services for project. */
 public class EnableServicesStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(EnableServicesStep.class);
-  private final ServiceUsageCow serviceUsageCow;
   private final GcpProjectConfig gcpProjectConfig;
+  private final ClientConfig clientConfig;
 
-  public EnableServicesStep(ServiceUsageCow serviceUsageCow, GcpProjectConfig gcpProjectConfig) {
-    this.serviceUsageCow = serviceUsageCow;
+  public EnableServicesStep(GcpProjectConfig gcpProjectConfig, ClientConfig clientConfig) {
     this.gcpProjectConfig = gcpProjectConfig;
+    this.clientConfig = clientConfig;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
-    // Skip if enable apis is not set or empty.
-    if (gcpProjectConfig.getEnabledApis() == null || gcpProjectConfig.getEnabledApis().isEmpty()) {
-      return StepResult.getStepResultSuccess();
-    }
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);
     try {
+      ServiceUsageCow serviceUsageCow =
+          new ServiceUsageCow(
+              clientConfig,
+              new ServiceUsage.Builder(
+                      GoogleNetHttpTransport.newTrustedTransport(),
+                      Defaults.jsonFactory(),
+                      setUserProject(
+                          new HttpCredentialsAdapter(
+                              GoogleCredentials.getApplicationDefault()
+                                  .createScoped(ComputeScopes.all())),
+                          projectId))
+                  .setApplicationName(CLIENT_NAME));
+
+      // Skip if enable apis is not set or empty.
+      if (gcpProjectConfig.getEnabledApis() == null
+          || gcpProjectConfig.getEnabledApis().isEmpty()) {
+        return StepResult.getStepResultSuccess();
+      }
       OperationCow<?> operation =
           serviceUsageCow
               .operations()
@@ -49,7 +71,7 @@ public class EnableServicesStep implements Step {
                               .setServiceIds(gcpProjectConfig.getEnabledApis()))
                       .execute());
       pollUntilSuccess(operation, Duration.ofSeconds(5), Duration.ofMinutes(5));
-    } catch (IOException | InterruptedException e) {
+    } catch (IOException | InterruptedException | GeneralSecurityException e) {
       logger.info("Error enabling services GCP project, id: {}", projectId, e);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectCreationFlight.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectCreationFlight.java
@@ -45,7 +45,7 @@ public class GoogleProjectCreationFlight extends Flight {
     addStep(new GenerateProjectIdStep(gcpProjectConfig, idGenerator), CLOUD_API_DEFAULT_RETRY);
     addStep(new CreateProjectStep(rmCow, gcpProjectConfig), CLOUD_API_DEFAULT_RETRY);
     addStep(new SetBillingInfoStep(billingCow, gcpProjectConfig), CLOUD_API_DEFAULT_RETRY);
-    addStep(new EnableServicesStep(serviceUsageCow, gcpProjectConfig), CLOUD_API_DEFAULT_RETRY);
+    addStep(new EnableServicesStep(gcpProjectConfig, clientConfig), CLOUD_API_DEFAULT_RETRY);
     addStep(new SetIamPolicyStep(rmCow, gcpProjectConfig), CLOUD_API_DEFAULT_RETRY);
     addStep(
         new CreateStorageLogBucketStep(clientConfig, gcpProjectConfig), CLOUD_API_DEFAULT_RETRY);

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleUtils.java
@@ -6,6 +6,7 @@ import bio.terra.cloudres.google.api.services.common.OperationUtils;
 import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.stairway.exception.RetryException;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -23,6 +24,12 @@ public class GoogleUtils {
 
   /** All project will use the same sub network name. */
   @VisibleForTesting public static final String SUBNETWORK_NAME = "subnetwork";
+
+  /**
+   * A caller-specified project for quota and billing purposes. The caller must have
+   * serviceusage.services.use permission on the project.
+   */
+  private static final String USER_PROJECT_HEADER_NAME = "X-Goog-User-Project";
 
   /**
    * Poll until the Google Service API operation has completed. Throws any error or timeouts as a
@@ -121,5 +128,14 @@ public class GoogleUtils {
   @FunctionalInterface
   public interface CloudExecute<R> {
     R execute() throws IOException;
+  }
+
+  /** Sets X-Goog-User-Project in request header to let Google use quota project. */
+  public static HttpRequestInitializer setUserProject(
+      final HttpRequestInitializer requestInitializer, String projectId) {
+    return httpRequest -> {
+      requestInitializer.initialize(httpRequest);
+      httpRequest.getResponseHeaders().set(USER_PROJECT_HEADER_NAME, projectId);
+    };
   }
 }


### PR DESCRIPTION
Background: We saw many429 errors for enable projects in Buffer perf test. 
My finding: GCP uses the same quota system and they use ResourceManager quota as the quota 'baseline'. For serviceusage, the qps is the same as ResourceManager. (100/100s).

But one batchEnable equals to 5 writes: 
https://cloud.google.com/service-usage/docs/pricing-and-quotas?hl=en
So this quota is 20/100s, and that is why we are seeing that many errors. 

Full solution can be found in this doc: https://docs.google.com/document/d/1f2glkLyGtZLDik0Ntdemx3ItamkBwq5zagYpwZJcGew/edit?resourcekey=0-7PffuFBpIeK0GREU4g4-5w#

For now, I only does it for serviceUsage API as that is the only error I saw besides ResourceManager. 