### PR TITLE
PF-338 Enable notebooks API for workspace_manager configs

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -27,3 +27,6 @@ poolConfigs:
   - poolId: "workspace_manager_v4"
     size: 20
     resourceConfigName: "workspace_manager_v4"
+  - poolId: "workspace_manager_v5"
+    size: 20
+    resourceConfigName: "workspace_manager_v5"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v5.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v5.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v5"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-dev"
+    scheme: "RANDOM_CHAR"
+  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/perf/pool_schema.yml
+++ b/src/main/resources/config/perf/pool_schema.yml
@@ -13,3 +13,6 @@ poolConfigs:
   - poolId: "workspace_manager_v4"
     size: 20
     resourceConfigName: "workspace_manager_v4"
+  - poolId: "workspace_manager_v5"
+    size: 20
+    resourceConfigName: "workspace_manager_v5"

--- a/src/main/resources/config/perf/resource-config/workspace_manager_v5.yml
+++ b/src/main/resources/config/perf/resource-config/workspace_manager_v5.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v5"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-dev"
+    scheme: "RANDOM_CHAR"
+  parentFolderId: "199572063713"  #test.firecloud.org/perf/buffer-perf/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -16,3 +16,6 @@ poolConfigs:
   - poolId: "workspace_manager_v3"
     size: 100
     resourceConfigName: "workspace_manager_v3"
+  - poolId: "workspace_manager_v4"
+    size: 100
+    resourceConfigName: "workspace_manager_v4"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v4.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v4.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v4"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-test"
+    scheme: "RANDOM_CHAR"
+  parentFolderId: "375605435272" #test.firecloud.org/tools/buffer-tools/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"


### PR DESCRIPTION
Add "notebooks.googleapis.com" to the `enabledApis`. We need this API for working with AI Platform Notebooks.

Planed process:
1. Wait for this to roll out to associated buffer deployments
2. Update the `terra-helmfile` repo to update the workspace manager configs for the new pool id. (https://github.com/broadinstitute/terra-helmfile/pull/918)
3. Wait for redeployments in all workspace manager environments
4. Delete the obsolete workspace_manager pools here.