### PR TITLE
PF-440: Bump test runner library version.

### DIFF
--- a/buffer-clienttests/build.gradle
+++ b/buffer-clienttests/build.gradle
@@ -31,7 +31,7 @@ dependencies {
         googleOauth2 = "0.20.0"
 
         bufferServiceClient = "0.4.3-SNAPSHOT"
-        testRunner = "0.0.1-SNAPSHOT"
+        testRunner = "0.0.2-SNAPSHOT"
     }
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"


### PR DESCRIPTION
Bump Test Runner library version from 0.0.1-SNAPSHOT to 0.0.2-SNAPSHOT.

This bump includes a change so that the isFailure flag is set on errors in the setup/cleanup methods, in addition to the userJourney methods. This should cause the GH action to fail if there is an exception in the setup/cleanup methods also. Previously, it only failed if there was an exception in the userJourney methods.