### PR TITLE
[PF-365] Add AppSec Github Trivy Action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,7 +1,5 @@
 name: dsp-appsec-trivy
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,44 @@
+name: dsp-appsec-trivy
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  appsec-trivy:
+    # Parse Dockerfile and build, scan image if a "blessed" base image is not used
+    name: DSP AppSec Trivy check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # fetch JDK
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '11'
+
+    # set up Gradle cache
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key:
+          gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          gradle-
+    # build the image
+    - name: Build
+      id: build
+      run: |
+        # build sources and store the plain log without colors
+        ./gradlew jibDockerBuild --console=plain \
+          | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log
+        # export image name from the log
+        image=$(grep 'Built image' build.log | awk '{print $NF}')
+        echo "::set-output name=image::${image}"
+    # scan the image
+    - uses: broadinstitute/dsp-appsec-trivy-action@v1
+      with:
+        image: ${{ steps.build.outputs.image }}


### PR DESCRIPTION
This change adds Trivy security scan for the Docker image, as discussed in the Workbench Cross-Team meeting.

The action will run on every PR and give you feedback if the Docker image contains critical OS vulnerabilities.

More info:
https://github.com/broadinstitute/dsp-appsec-trivy-action
https://github.com/broadinstitute/dsp-appsec-blessed-images