### PR TITLE
[CA-1084] project setup scripts

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -30,3 +30,9 @@ poolConfigs:
   - poolId: "workspace_manager_v5"
     size: 20
     resourceConfigName: "workspace_manager_v5"
+  - poolId: "aou_ws_test_v3"
+    size: 100
+    resourceConfigName: "aou_ws_resource_test_v3"
+  - poolId: "cwb_ws_dev_v3"
+    size: 20
+    resourceConfigName: "cwb_ws_resource_dev_v3"

--- a/src/main/resources/config/dev/resource-config/aou_ws_resource_test_v3.yml
+++ b/src/main/resources/config/dev/resource-config/aou_ws_resource_test_v3.yml
@@ -1,0 +1,33 @@
+# All Of Us buffered workspace template
+---
+configName: "aou_ws_resource_test_v3"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "aou-rw-test"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/terra_dev_aou_test
+  parentFolderId: "737976594150"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  iamBindings:
+    - members: [ "group:terra-billing@test.firecloud.org", "group:firecloud-project-owners@test.firecloud.org" ]
+      role: "roles/owner"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v3.yml
+++ b/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v3.yml
@@ -1,0 +1,33 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_resource_dev_v3"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-dev"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/dev/CommunityWorkbench
+  parentFolderId: "803412578462"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  iamBindings:
+    - members: [ "group:terra-billing@test.firecloud.org", "group:firecloud-project-owners@test.firecloud.org" ]
+      role: "roles/owner"
+  network:
+    enableNetworkMonitoring: "false"

--- a/src/main/resources/config/perf/pool_schema.yml
+++ b/src/main/resources/config/perf/pool_schema.yml
@@ -16,3 +16,6 @@ poolConfigs:
   - poolId: "workspace_manager_v5"
     size: 20
     resourceConfigName: "workspace_manager_v5"
+  - poolId: "resource_perf_v3"
+    size: 1500
+    resourceConfigName: "resource_perf_v3"

--- a/src/main/resources/config/perf/resource-config/resource_perf_v3.yml
+++ b/src/main/resources/config/perf/resource-config/resource_perf_v3.yml
@@ -1,0 +1,37 @@
+# Resource template for running buffer service performance test
+---
+configName: "resource_perf_v3"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-perf"
+    scheme: "RANDOM_CHAR"
+  # RBS Testing
+  parentFolderId: "637867149294"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  iamBindings:
+    - members: ["group:terra-rbs-test@broadinstitute.org"]
+      role: "roles/editor"
+    - members: ["group:terra-rbs-viewer-test@broadinstitute.org"]
+      role: "roles/viewer"
+    - members: [ "group:terra-billing@test.firecloud.org", "group:firecloud-project-owners@test.firecloud.org" ]
+      role: "roles/owner"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -19,3 +19,6 @@ poolConfigs:
   - poolId: "workspace_manager_v4"
     size: 100
     resourceConfigName: "workspace_manager_v4"
+  - poolId: "cwb_ws_fiab_v3"
+    size: 100
+    resourceConfigName: "cwb_ws_resource_fiab_v3"

--- a/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v3.yml
+++ b/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v3.yml
@@ -27,7 +27,8 @@ gcpProjectConfig:
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
   iamBindings:
-    - members: [ "group:terra-billing@test.firecloud.org", "group:firecloud-project-owners@test.firecloud.org" ]
+    - members: [ "group:terra-billing@test.firecloud.org", "group:firecloud-project-owners@test.firecloud.org",
+                 "group:terra-billing@quality.firecloud.org", "group:firecloud-project-owners@quality.firecloud.org" ]
       role: "roles/owner"
   network:
     enableNetworkMonitoring: "false"

--- a/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v3.yml
+++ b/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v3.yml
@@ -1,0 +1,33 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_resource_fiab_v3"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-test"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/tools/CommunityWorkbench
+  parentFolderId: "595081786611"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  iamBindings:
+    - members: [ "group:terra-billing@test.firecloud.org", "group:firecloud-project-owners@test.firecloud.org" ]
+      role: "roles/owner"
+  network:
+    enableNetworkMonitoring: "false"

--- a/src/main/resources/config/toolsalpha/pool_schema.yml
+++ b/src/main/resources/config/toolsalpha/pool_schema.yml
@@ -7,4 +7,7 @@ poolConfigs:
   - poolId: "resource_toolsalpha_v2"
     size: 3
     resourceConfigName: "resource_toolsalpha_v2"
+  - poolId: "resource_toolsalpha_v3"
+    size: 3
+    resourceConfigName: "resource_toolsalpha_v3"
 

--- a/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v3.yml
+++ b/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v3.yml
@@ -1,0 +1,37 @@
+# Resource template for local testing and personal environment on GKE
+---
+configName: "resource_toolsalpha_v3"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-toolsalpha"
+    scheme: "RANDOM_CHAR"
+  # RBS Testing
+  parentFolderId: "637867149294"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  iamBindings:
+    - members: ["group:terra-rbs-test@broadinstitute.org"]
+      role: "roles/editor"
+    - members: ["group:terra-rbs-viewer-test@broadinstitute.org"]
+      role: "roles/viewer"
+    - members: [ "group:terra-billing@test.firecloud.org", "group:firecloud-project-owners@test.firecloud.org" ]
+      role: "roles/owner"
+  network:
+    enableNetworkMonitoring: "true"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CA-1084

These yamls were copied from the existing (v2) yamls and version bumped. The enabled APIs are the same as in DM. The groups (terra-billing@test.firecloud.org and firecloud-project-owners@test.firecloud.org) were added to follow what Rawls / DM currently does.

Arguably, instead of adding those groups to each test env project, we could add grant folder level permissions to both groups.

I made a spreadsheet that helped me track the permissions (it's a bit messy so I'd be happy to walk through it with folks): 
https://docs.google.com/spreadsheets/d/1n4BnfYIbEFSybKvh8WGbgbGNhYub8SdZexya8Pf5p4k/edit?pli=1#gid=1572590727

The PRs related to this set of changes are:
https://github.com/broadinstitute/rawls/pull/1369
https://github.com/broadinstitute/terraform-terra/pull/144
https://github.com/broadinstitute/firecloud-develop/pull/2445
https://github.com/DataBiosphere/terra-resource-buffer/pull/120