### PR TITLE
[PF-450] Switch to using the common logging package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ allprojects {
 }
 
 repositories {
+//  Uncomment to read from the local Maven cache.
+	mavenLocal()
     mavenCentral()
     maven {
         url 'https://broadinstitute.jfrog.io/broadinstitute/libs-release/'
@@ -61,12 +63,12 @@ dependencies {
     // Terra deps
     implementation group: 'bio.terra', name: 'stairway', version: '0.0.41-SNAPSHOT'
     implementation group: 'bio.terra', name: 'terra-common-lib', version: '0.0.25-SNAPSHOT'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'cloud-resource-schema'
+    implementation group: 'bio.terra.cloud-resource-lib', name: 'cloud-resource-schema', version: '0.5.0'
     implementation group: 'bio.terra.cloud-resource-lib', name: 'google-billing', version: '0.4.0'
     implementation group: 'bio.terra.cloud-resource-lib', name: 'google-cloudresourcemanager', version: '0.4.0'
     implementation group: 'bio.terra.cloud-resource-lib', name: 'google-compute', version: '0.4.2'
     implementation group: 'bio.terra.cloud-resource-lib', name: 'google-dns', version: '0.4.0'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-iam', version: '0.1.0'
+    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-iam', version: '0.2.0'
     implementation group: 'bio.terra.cloud-resource-lib', name: 'google-serviceusage', version: '0.4.0'
     implementation group: 'bio.terra.cloud-resource-lib', name: 'google-storage', version: '0.5.0'
     implementation group: 'bio.terra.janitor', name: 'terra-resource-janitor-client', version: '0.0.2-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ allprojects {
 
 repositories {
 //  Uncomment to read from the local Maven cache.
-	mavenLocal()
+//	mavenLocal()
     mavenCentral()
     maven {
         url 'https://broadinstitute.jfrog.io/broadinstitute/libs-release/'

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,14 +1,15 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra.cloud-resource-lib:cloud-resource-schema:0.4.0=cloudResourceSchema,compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra.cloud-resource-lib:cloud-resource-schema:0.4.0=cloudResourceSchema
+bio.terra.cloud-resource-lib:cloud-resource-schema:0.5.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:common:0.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-api-services-common:0.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-billing:0.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-cloudresourcemanager:0.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-compute:0.4.2=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-dns:0.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra.cloud-resource-lib:google-iam:0.1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra.cloud-resource-lib:google-iam:0.2.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-serviceusage:0.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-storage:0.5.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.janitor:terra-resource-janitor-client:0.0.2-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/src/main/java/bio/terra/buffer/app/Main.java
+++ b/src/main/java/bio/terra/buffer/app/Main.java
@@ -8,14 +8,15 @@ import org.springframework.context.annotation.ComponentScan;
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 @ComponentScan(
     basePackages = {
-      // Scan for Liquibase migration components & configs
+      // Logging components & configs
+      "bio.terra.common.logging",
+      // Liquibase migration components & configs
       "bio.terra.common.migrate",
-      // Scan for tracing-related components & configs
+      // Tracing-related components & configs
       "bio.terra.common.tracing",
       // Scan all service-specific packages beneath the current package
       "bio.terra.buffer"
     })
-@ComponentScan(basePackages = {"bio.terra.buffer", "bio.terra.common"})
 public class Main {
   public static void main(String[] args) {
     SpringApplication.run(Main.class, args);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,9 @@ buffer:
     quiet-down-timeout: 20s
     terminate-timeout: 5s
 
+# Turn on debug-level logs for CRL, to include all CRL operation payloads.
+logging.level.bio.terra.cloudres: DEBUG
+
 server:
   compression:
     enabled: true


### PR DESCRIPTION
Enables the common logging package for resource buffer and turns on debug-level logs for CRL.

DO NOT MERGE until the related common-lib and CRL PRs are merged too.
