### PR TITLE
[PF-619] Disable deleting resource when exceeding pool size

### DIFF
--- a/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
@@ -25,7 +25,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @ConfigurationProperties(prefix = "buffer.primary")
 public class PrimaryConfiguration {
 
-  /** Whether to run the scheduler to periodically. */
+  /**
+   * Whether to run the scheduler to periodically.
+   */
   private boolean schedulerEnabled;
 
   /**
@@ -43,7 +45,7 @@ public class PrimaryConfiguration {
    * is no use case that we need to actively reduce pool size. Resource is only need to be deleted
    * when pool is inactivated.
    */
-  private boolean deleteExcessResources;
+  private boolean deleteExcessResources = false;
 
   /**
    * How many resource creation flights for a pool to process simultaneously because because we

--- a/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
@@ -44,7 +44,7 @@ public class PrimaryConfiguration {
    * is no use case that we need to actively reduce pool size. Resource is only need to be deleted
    * when pool is inactivated.
    */
-  private boolean deleteExceedPoolSizeResource = false;
+  private boolean deleteExceedPoolSizeResource;
 
   /**
    * How many resource creation flights for a pool to process simultaneously because because we

--- a/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/PrimaryConfiguration.java
@@ -14,9 +14,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * seconds. If a scheduler runs every 10 seconds, in 900 seconds it schedulers runs 70 times. If we
  * have 4 pools, it schedules ({@code resourceCreationPerPoolLimit} * 4) = 4 flights. In total 70
  * times run, 280 flights is scheduled. We estimate this number should works when pool number is
- * 1~10. If we see more errors, we will comeback and revise those configs. TODO(PF-617): The current
- * 'primary' scheduling service is actually running in all instances, figure out a way to make this
- * only runs in one pod.
+ * 1~10. If we see more errors, we will comeback and revise those configs.
+ *
+ * <p>TODO(PF-617): The current 'primary' scheduling service is actually running in all instances,
+ * figure out a way to make this only runs in one pod.
  */
 @Component
 @EnableConfigurationProperties
@@ -24,18 +25,16 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @ConfigurationProperties(prefix = "buffer.primary")
 public class PrimaryConfiguration {
 
-  /**
-   * Whether to run the scheduler to periodically.
-   */
+  /** Whether to run the scheduler to periodically. */
   private boolean schedulerEnabled;
 
   /**
    * How often to query for flights to submit.
    *
-   * <p> Sets this to be a larger number because most of the service is deployed in a
-   * multi-instance world, and there will be more than one scheduling service running.
+   * <p>Sets this to be a larger number because most of the service is deployed in a multi-instance
+   * world, and there will be more than one scheduling service running.
    */
-  private Duration flightSubmissionPeriod = Duration.ofSeconds(20);
+  private Duration flightSubmissionPeriod = Duration.ofSeconds(30);
 
   /**
    * Whether to delete resource when resource count exceeds the pool size.
@@ -44,7 +43,7 @@ public class PrimaryConfiguration {
    * is no use case that we need to actively reduce pool size. Resource is only need to be deleted
    * when pool is inactivated.
    */
-  private boolean deleteExceedPoolSizeResource;
+  private boolean deleteExcessResources;
 
   /**
    * How many resource creation flights for a pool to process simultaneously because because we
@@ -90,11 +89,11 @@ public class PrimaryConfiguration {
     this.resourceDeletionPerPoolLimit = resourceDeletionPerPoolLimit;
   }
 
-  public boolean isDeleteExceedPoolSizeResource() {
-    return deleteExceedPoolSizeResource;
+  public boolean isDeleteExcessResources() {
+    return deleteExcessResources;
   }
 
-  public void setDeleteExceedPoolSizeResource(boolean deleteExceedPoolSizeResource) {
-    this.deleteExceedPoolSizeResource = deleteExceedPoolSizeResource;
+  public void setDeleteExcessResources(boolean deleteExcessResources) {
+    this.deleteExcessResources = deleteExcessResources;
   }
 }

--- a/src/main/java/bio/terra/buffer/service/resource/FlightScheduler.java
+++ b/src/main/java/bio/terra/buffer/service/resource/FlightScheduler.java
@@ -29,9 +29,7 @@ public class FlightScheduler {
 
   private final Logger logger = LoggerFactory.getLogger(FlightScheduler.class);
 
-  /**
-   * Only need as many threads as we have scheduled tasks.
-   */
+  /** Only need as many threads as we have scheduled tasks. */
   private final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
 
   private final FlightManager flightManager;
@@ -98,7 +96,7 @@ public class FlightScheduler {
             readyAndCreatingCount);
         if (size > readyAndCreatingCount) {
           scheduleCreationFlights(poolAndResources.pool(), size - readyAndCreatingCount);
-        } else if (primaryConfiguration.isDeleteExceedPoolSizeResource()
+        } else if (primaryConfiguration.isDeleteExcessResources()
             && poolAndResources.resourceStates().count(ResourceState.READY) > size) {
           // Only deletion READY resource, we hope future schedule runs will deletion resources
           // just turns to READY from CREATING.
@@ -115,9 +113,7 @@ public class FlightScheduler {
     }
   }
 
-  /**
-   * Schedules up to {@code number} of resources creation flight for a pool.
-   */
+  /** Schedules up to {@code number} of resources creation flight for a pool. */
   private void scheduleCreationFlights(Pool pool, int number) {
     int flightToSchedule = Math.min(primaryConfiguration.getResourceCreationPerPoolLimit(), number);
     logger.info(
@@ -137,9 +133,7 @@ public class FlightScheduler {
         pool.id());
   }
 
-  /**
-   * Schedules up to {@code number} of resources creation flight for a pool.
-   */
+  /** Schedules up to {@code number} of resources creation flight for a pool. */
   private void scheduleDeletionFlights(Pool pool, int number) {
     int flightToSchedule = Math.min(primaryConfiguration.getResourceDeletionPerPoolLimit(), number);
     logger.info(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,8 +6,6 @@ buffer:
     uri: jdbc:postgresql://127.0.0.1:5432/${BUFFER_DATABASE_NAME}
     username:
   primary:
-    # Don't delete resource when ready resource count exceeds pool size.
-    delete-excess-resources: false
     scheduler-enabled: true
   pool:
     # The Folder to have all Resource Buffer Service configs.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ buffer:
     uri: jdbc:postgresql://127.0.0.1:5432/${BUFFER_DATABASE_NAME}
     username:
   primary:
+    # Don't delete resource when ready resource count exceeds pool size.
+    delete-exceed-pool-size-resource: false
     scheduler-enabled: true
   pool:
     # The Folder to have all Resource Buffer Service configs.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ buffer:
     username:
   primary:
     # Don't delete resource when ready resource count exceeds pool size.
-    delete-exceed-pool-size-resource: false
+    delete-excess-resources: false
     scheduler-enabled: true
   pool:
     # The Folder to have all Resource Buffer Service configs.

--- a/src/test/resources/application-integration-enable-scheduler.yml
+++ b/src/test/resources/application-integration-enable-scheduler.yml
@@ -3,4 +3,4 @@ buffer:
     # Enable scheduler service which will submit flight by scanning db.
     scheduler-enabled: true
     flight-submission-period: 5s
-    delete-exceed-pool-size-resource: true
+    delete-excess-resources: true

--- a/src/test/resources/application-integration-enable-scheduler.yml
+++ b/src/test/resources/application-integration-enable-scheduler.yml
@@ -3,3 +3,4 @@ buffer:
     # Enable scheduler service which will submit flight by scanning db.
     scheduler-enabled: true
     flight-submission-period: 5s
+    delete-exceed-pool-size-resource: true


### PR DESCRIPTION
This is the short-term of 'Primary Job' in Buffer doc:
https://docs.google.com/document/d/1rSIXOrDQYCgptHZIxnxXjM-nHjb_ohxxNGKAl5ZarKw/edit#heading=h.5inn55b6pv26

As Doug suggested "For: down sizing... Currently we don't really need to actively reduce the size"
This also increases the frequency of scheduling service runs.