### PR TITLE
PF-618 Only log errors and fatals from the cloud profiler agent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ jib {
                         ',-cprof_service_version=' + version +
                         ',-cprof_enable_heap_sampling=true' +
                         ',-logtostderr' +
-                        ',-minloglevel=1'
+                        ',-minloglevel=2'
         ]
     }
 }


### PR DESCRIPTION
No longer log warnings to bring the buffer in line with other services.