### PR TITLE
[PF-561]: Few minor improvements: Add index on resource table, avoid on unnecessary db query

### DIFF
--- a/local-dev/run_local.sh
+++ b/local-dev/run_local.sh
@@ -6,7 +6,6 @@ export BUFFER_DB_RECREATE_DB_ON_START=true
 export BUFFER_DATABASE_NAME=testdb
 export BUFFER_STAIRWAY_DB_USERNAME=dbuser_stairway
 export BUFFER_STAIRWAY_DB_PASSWORD=dbpwd_stairway
-export BUFFER_STAIRWAY_DB_FORCE_CLEAN_START=true
 export BUFFER_STAIRWAY_DATABASE_NAME=testdb_stairway
 export GOOGLE_APPLICATION_CREDENTIALS="$(dirname $0)"/../src/test/resources/rendered/sa-account.json
 export BUFFER_CRL_TESTING_MODE=true
@@ -15,5 +14,6 @@ export BUFFER_CRL_JANITOR_TRACK_RESOURCE_PROJECT_ID=terra-kernel-k8s
 export BUFFER_CRL_JANITOR_TRACK_RESOURCE_TOPIC_ID=crljanitor-tools-pubsub-topic
 export BUFFER_POOL_CONFIG_PATH=config/toolsalpha
 export SPRING_PROFILES_INCLUDE=human-readable-logging
+export TERRA_COMMON_STAIRWAY_DB_FORCE_CLEAN_START=true
 
 ./gradlew bootRun

--- a/src/main/java/bio/terra/buffer/service/resource/FlightScheduler.java
+++ b/src/main/java/bio/terra/buffer/service/resource/FlightScheduler.java
@@ -135,6 +135,9 @@ public class FlightScheduler {
 
   /** Schedules up to {@code number} of resources creation flight for a pool. */
   private void scheduleDeletionFlights(Pool pool, int number) {
+    if(number == 0) {
+      return;
+    }
     int flightToSchedule = Math.min(primaryConfiguration.getResourceDeletionPerPoolLimit(), number);
     logger.info(
         "Beginning resource deletion flights for pool: {}, target submission number: {} .",

--- a/src/main/java/bio/terra/buffer/service/resource/FlightScheduler.java
+++ b/src/main/java/bio/terra/buffer/service/resource/FlightScheduler.java
@@ -135,7 +135,7 @@ public class FlightScheduler {
 
   /** Schedules up to {@code number} of resources creation flight for a pool. */
   private void scheduleDeletionFlights(Pool pool, int number) {
-    if(number == 0) {
+    if (number == 0) {
       return;
     }
     int flightToSchedule = Math.min(primaryConfiguration.getResourceDeletionPerPoolLimit(), number);

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <include file="changesets/20200925_initial_schema.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210405_add_resource_state_index.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210405_add_resource_state_index.yaml
+++ b/src/main/resources/db/changesets/20210405_add_resource_state_index.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: changelog_1_add_resource_state_index
+      author: yonghaoy
+      changes:
+      - createIndex:
+          clustered:  true
+          columns:
+            - column:
+                descending:  true
+                name:  state
+          indexName:  resource_state_index
+          tableName:  resource
+          unique:  false

--- a/src/main/resources/db/changesets/20210405_add_resource_state_index.yaml
+++ b/src/main/resources/db/changesets/20210405_add_resource_state_index.yaml
@@ -4,7 +4,6 @@ databaseChangeLog:
       author: yonghaoy
       changes:
       - createIndex:
-          clustered:  true
           columns:
             - column:
                 descending:  true


### PR DESCRIPTION
1. AoU also has a similar buffer service. Recently we observe slowness in the AoU buffer service when handout resource. That is caused by too many non-READY resource slows down query. As our resource table is heavily used by handout, schedulling service, I think it make sense to add index.
2. Also, remove the unnecessary query when deleting resources(a Pool is deactivated for a while, we are still trying to make a query on that table everytime).
3. Fix env variable in local run script.

```
testdb=> select *
from pg_indexes where tablename = 'resource';
 schemaname | tablename |      indexname       | tablespace |                                   indexdef                                    
------------+-----------+----------------------+------------+-------------------------------------------------------------------------------
 public     | resource  | resource_pkey        |            | CREATE UNIQUE INDEX resource_pkey ON public.resource USING btree (id)
 public     | resource  | resource_state_index |            | CREATE INDEX resource_state_index ON public.resource USING btree (state DESC)
```