### PR TITLE
[CA-1139] Increase RBS Pool sizes to accommodate integration tests

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -2,12 +2,12 @@
 ---
 poolConfigs:
   - poolId: "cwb_ws_dev_v2"
-    size: 300
+    size: 1000
     resourceConfigName: "cwb_ws_resource_dev_v2"
   - poolId: "workspace_manager_v6"
-    size: 300
+    size: 1000
     resourceConfigName: "workspace_manager_v6"
   - poolId: "vpc_sc_v1"
-    size: 300
+    size: 1000
     resourceConfigName: "vpc_sc_v1"
 


### PR DESCRIPTION
This should increase the RBS dev pool sizes to 1000 (if I am understanding the configs correctly). This is an attempt to make the dev pool sizes large enough for the integration tests to run comfortably. I figure starting with 1000, we can increase by more over time as we see what our demand looks like.