### PR TITLE
[no ticket] remove redundant expiration field set.

### DIFF
--- a/src/main/java/bio/terra/buffer/service/cleanup/CleanupScheduler.java
+++ b/src/main/java/bio/terra/buffer/service/cleanup/CleanupScheduler.java
@@ -123,7 +123,6 @@ public class CleanupScheduler {
                       objectMapper.writeValueAsString(cloudResourceUid),
                       bio.terra.janitor.model.CloudResourceUid.class))
               .creation(now)
-              .expiration(Instant.now().plus(TEST_RESOURCE_TIME_TO_LIVE).atOffset(ZoneOffset.UTC))
               .expiration(now.plus(TEST_RESOURCE_TIME_TO_LIVE))
               .putLabelsItem("client", CLIENT_NAME);
       data = ByteString.copyFromUtf8(objectMapper.writeValueAsString(body));


### PR DESCRIPTION
Setting the expiration twice on subsequent lines doesn't do anything. tiny nit fix.