### PR TITLE
[PF-806]remove compute api restriction

### DIFF
--- a/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
@@ -12,14 +12,9 @@ import java.util.List;
  *
  * <ul>
  *   <li>Billing account is present.
- *   <li>compute.googleapis.com need to be enabled.
  * </ul>
  */
 public class GcpResourceConfigValidator implements ResourceConfigValidator {
-  /** List of services required to be enabled. */
-  private static final List<String> REQUIRED_SERVICES =
-      ImmutableList.of("storage-component.googleapis.com");
-
   @Override
   public void validate(ResourceConfig config) {
     GcpProjectConfig gcpProjectConfig = config.getGcpProjectConfig();
@@ -27,12 +22,6 @@ public class GcpResourceConfigValidator implements ResourceConfigValidator {
         || gcpProjectConfig.getBillingAccount().isEmpty()) {
       throw new InvalidPoolConfigException(
           String.format("Missing billing account for config: %s", config.getConfigName()));
-    }
-
-    if (gcpProjectConfig.getEnabledApis() == null
-        || !gcpProjectConfig.getEnabledApis().containsAll(REQUIRED_SERVICES)) {
-      throw new InvalidPoolConfigException(
-          String.format("Missing required enabledApis for config: %s", config.getConfigName()));
     }
   }
 }

--- a/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class GcpResourceConfigValidator implements ResourceConfigValidator {
   /** List of services required to be enabled. */
   private static final List<String> REQUIRED_SERVICES =
-      ImmutableList.of("compute.googleapis.com", "storage-component.googleapis.com");
+      ImmutableList.of("storage-component.googleapis.com");
 
   @Override
   public void validate(ResourceConfig config) {

--- a/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
+++ b/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.Test;
 public class ResourceConfigValidatorTest extends BaseUnitTest {
   private static GcpProjectConfig newValidGcpProjectConfig() {
     return new GcpProjectConfig()
-        .billingAccount("123")
-        .addEnabledApisItem("storage-component.googleapis.com");
+        .billingAccount("123");
   }
 
   @Test
@@ -34,19 +33,5 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
             InvalidPoolConfigException.class,
             () -> new GcpResourceConfigValidator().validate(resourceConfig));
     assertTrue(exception.getMessage().contains("Missing billing account"));
-  }
-
-  @Test
-  public void testValidateGcpConfig_missingRequiredApis() {
-    ResourceConfig resourceConfig =
-        new ResourceConfig()
-            .configName("testConfig")
-            .gcpProjectConfig(
-                newValidGcpProjectConfig().enabledApis(ImmutableList.of("foo.googleapis.com")));
-    InvalidPoolConfigException exception =
-        assertThrows(
-            InvalidPoolConfigException.class,
-            () -> new GcpResourceConfigValidator().validate(resourceConfig));
-    assertTrue(exception.getMessage().contains("Missing required enabledApis"));
   }
 }

--- a/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
+++ b/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
@@ -13,7 +13,6 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
   private static GcpProjectConfig newValidGcpProjectConfig() {
     return new GcpProjectConfig()
         .billingAccount("123")
-        .addEnabledApisItem("compute.googleapis.com")
         .addEnabledApisItem("storage-component.googleapis.com");
   }
 


### PR DESCRIPTION
Initially we have restriction that all pool config must have compute API enabled because those projects power “Terra workspace” which means user need compute. But with Buffer Service adopted by Data Repo, that’s true anymore. 

We may want to remove this restriction and unblock TDR integration  