### PR TITLE
PF-538 (part 1): Add workspace_manager_v4 pool for tools environment.

### DIFF
--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -7,12 +7,12 @@ poolConfigs:
   - poolId: "cwb_ws_quality_v2"
     size: 500
     resourceConfigName: "cwb_ws_resource_quality_v2"
-  - poolId: "workspace_manager_v4"
-    size: 500
-    resourceConfigName: "workspace_manager_v4"
   - poolId: "workspace_manager_v6"
     size: 500
     resourceConfigName: "workspace_manager_v6"
+  - poolId: "workspace_manager_v7"
+    size: 500
+    resourceConfigName: "workspace_manager_v4"
   - poolId: "datarepo_v1"
     size: 500
     resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -7,6 +7,9 @@ poolConfigs:
   - poolId: "cwb_ws_quality_v2"
     size: 500
     resourceConfigName: "cwb_ws_resource_quality_v2"
+  - poolId: "workspace_manager_v4"
+    size: 500
+    resourceConfigName: "workspace_manager_v4"
   - poolId: "workspace_manager_v6"
     size: 500
     resourceConfigName: "workspace_manager_v6"


### PR DESCRIPTION
Added the `workspace_manager_v4` pool to the schema for the tools environment.

The current `v6` pool does not delete the default compute engine service account or the default VPC network. This was to support Nextflow, which required both of these things. Now there is a Nextflow edge release that allows overriding both defaults.

I am enabling the `v4` pool for the tools environment to test this against my personal environment WSM and updated CLI code. Once I confirm that works, I'll make a similar change here to enable the `v5` pool for the dev environment. (Tools pool id went from `v4`->`v6`, dev went from `v5`->`v6`) And then update the helmfile for all WSM deployments to point to these pools.