### PR TITLE
PF-538 (part 2): Add workspace_manager_v8 pools for tools, dev environments.

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -7,6 +7,9 @@ poolConfigs:
   - poolId: "workspace_manager_v6"
     size: 300
     resourceConfigName: "workspace_manager_v6"
+  - poolId: "workspace_manager_v7"
+    size: 500
+    resourceConfigName: "workspace_manager_v5"
   - poolId: "vpc_sc_v1"
     size: 300
     resourceConfigName: "vpc_sc_v1"

--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -7,9 +7,9 @@ poolConfigs:
   - poolId: "workspace_manager_v6"
     size: 300
     resourceConfigName: "workspace_manager_v6"
-  - poolId: "workspace_manager_v7"
+  - poolId: "workspace_manager_v8"
     size: 500
-    resourceConfigName: "workspace_manager_v5"
+    resourceConfigName: "workspace_manager_v8"
   - poolId: "vpc_sc_v1"
     size: 300
     resourceConfigName: "vpc_sc_v1"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v8.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v8.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v8"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-dev"
+    scheme: "RANDOM_CHAR"
+  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -13,6 +13,9 @@ poolConfigs:
   - poolId: "workspace_manager_v7"
     size: 500
     resourceConfigName: "workspace_manager_v4"
+  - poolId: "workspace_manager_v8"
+    size: 500
+    resourceConfigName: "workspace_manager_v8"
   - poolId: "datarepo_v1"
     size: 500
     resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v8.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v8.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v8"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-test"
+    scheme: "RANDOM_CHAR"
+  parentFolderId: "375605435272" #test.firecloud.org/tools/buffer-tools/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"


### PR DESCRIPTION
Added the `workspace_manager_v8` pool and accompanying resource config to the tools and dev environment. These resource configs are identical to the `_v5` for dev and `_v4` for tools. They are copy/pasted into a new file to make future cleanup easier (see review comments).

The new pools do not delete the default compute engine service account or the default VPC network. This was to support Nextflow, which required both of these things. Now there is a Nextflow edge release that allows overriding both defaults.

I've tested this against my personal environment WSM and updated CLI code. Next I will update the helmfile for all WSM dev/tools deployments to point to these pools.