### PR TITLE
[ca-1434] created new pools for perf/prod in order to remove unused notebook API

### DIFF
--- a/src/main/resources/config/perf/pool_schema.yml
+++ b/src/main/resources/config/perf/pool_schema.yml
@@ -14,13 +14,13 @@ poolConfigs:
     size: 500
     resourceConfigName: "cwb_ws_perf_v1"
   - poolId: "cwb_ws_perf_v2"
-    size: 1000
+    size: 500
     resourceConfigName: "cwb_ws_perf_v2"
   - poolId: "vpc_sc_v1"
     size: 500
     resourceConfigName: "vpc_sc_v1"
   - poolId: "vpc_sc_v2"
-    size: 1000
+    size: 500
     resourceConfigName: "vpc_sc_v2"
   - poolId: "datarepo_v1"
     size: 300

--- a/src/main/resources/config/perf/pool_schema.yml
+++ b/src/main/resources/config/perf/pool_schema.yml
@@ -13,9 +13,15 @@ poolConfigs:
   - poolId: "cwb_ws_perf_v1"
     size: 500
     resourceConfigName: "cwb_ws_perf_v1"
+  - poolId: "cwb_ws_perf_v2"
+    size: 1000
+    resourceConfigName: "cwb_ws_perf_v2"
   - poolId: "vpc_sc_v1"
     size: 500
     resourceConfigName: "vpc_sc_v1"
+  - poolId: "vpc_sc_v2"
+    size: 1000
+    resourceConfigName: "vpc_sc_v2"
   - poolId: "datarepo_v1"
     size: 300
     resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/perf/resource-config/cwb_ws_perf_v2.yml
+++ b/src/main/resources/config/perf/resource-config/cwb_ws_perf_v2.yml
@@ -1,0 +1,30 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_perf_v2"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-perf"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/perf/CommunityWorkbench
+  parentFolderId: "246142551922"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"

--- a/src/main/resources/config/perf/resource-config/vpc_sc_v2.yml
+++ b/src/main/resources/config/perf/resource-config/vpc_sc_v2.yml
@@ -1,0 +1,30 @@
+# Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v2"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-perf"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/perf/for_vpc_sc_unclaimed
+  parentFolderId: "533417334224"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/prod/pool_schema.yml
+++ b/src/main/resources/config/prod/pool_schema.yml
@@ -4,9 +4,15 @@ poolConfigs:
   - poolId: "cwb_ws_prod_v1"
     size: 3000
     resourceConfigName: "cwb_ws_prod_v1"
+  - poolId: "cwb_ws_prod_v2"
+    size: 3000
+    resourceConfigName: "cwb_ws_prod_v2"
   - poolId: "vpc_sc_v1"
     size: 1000
     resourceConfigName: "vpc_sc_v1"
+  - poolId: "vpc_sc_v2"
+    size: 1000
+    resourceConfigName: "vpc_sc_v2"
   - poolId: "datarepo_v1"
     size: 1000
     resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/prod/resource-config/cwb_ws_prod_v2.yml
+++ b/src/main/resources/config/prod/resource-config/cwb_ws_prod_v2.yml
@@ -1,0 +1,30 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_prod_v2"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra"
+    scheme: "RANDOM_CHAR"
+  # firecloud.org/prod/CommunityWorkbench
+  parentFolderId: "710468670182"
+  billingAccount: "0106B0-41CAA9-427C96"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"

--- a/src/main/resources/config/prod/resource-config/vpc_sc_v2.yml
+++ b/src/main/resources/config/prod/resource-config/vpc_sc_v2.yml
@@ -1,0 +1,30 @@
+# Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v2"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc"
+    scheme: "RANDOM_CHAR"
+  # firecloud.org/prod/for_vpc_sc_unclaimed
+  parentFolderId: "160283235721"
+  billingAccount: "0106B0-41CAA9-427C96"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"


### PR DESCRIPTION
In order to keep projects consistent across envs, we discussed creating new pools: #168 (comment) This PR handles that extra change.


related PR: https://github.com/broadinstitute/firecloud-develop/pull/2596

