### PR TITLE
Add workflow_dispatch for tag/build/push task.

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -6,7 +6,8 @@ on:
     - master
     paths-ignore:
     - 'README.md'
-    - '.github/**'
+  workflow_dispatch: {}
+
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
   GOOGLE_PROJECT: terra-kernel-k8s


### PR DESCRIPTION
My [last PR](https://github.com/DataBiosphere/terra-resource-buffer/pull/174) attempted to fix the tag/build/push github action, but it did not run due to ignoring `.github/**`.  This PR removes that ignore so that future changes to the action will get applied immediately.  I also add a `workflow_dispatch` to allow manual running of the action.