### PR TITLE
PF-228: Validate generated project id. Restrict prefix length.

### DIFF
--- a/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
@@ -4,6 +4,7 @@ import static bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator.
 
 import bio.terra.buffer.common.exception.InvalidPoolConfigException;
 import bio.terra.buffer.generated.model.GcpProjectConfig;
+import bio.terra.buffer.generated.model.ProjectIdSchema;
 import bio.terra.buffer.generated.model.ResourceConfig;
 
 /**
@@ -23,10 +24,16 @@ public class GcpResourceConfigValidator implements ResourceConfigValidator {
       throw new InvalidPoolConfigException(
           String.format("Missing billing account for config: %s", config.getConfigName()));
     }
-    if (gcpProjectConfig.getProjectIdSchema().getPrefix().length()
-        > MAX_LENGTH_GCP_PROJECT_ID_PREFIX) {
+    if (gcpProjectConfig
+            .getProjectIdSchema()
+            .getScheme()
+            .equals(ProjectIdSchema.SchemeEnum.TWO_WORDS_NUMBER)
+        && gcpProjectConfig.getProjectIdSchema().getPrefix().length()
+            > MAX_LENGTH_GCP_PROJECT_ID_PREFIX) {
       throw new InvalidPoolConfigException(
-          String.format("Project id prefix is too long: %s", config.getConfigName()));
+          String.format(
+              "Project id prefix is too long for TWO_WORDS_NUMBER naming scheme: %s",
+              config.getConfigName()));
     }
   }
 }

--- a/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
@@ -1,5 +1,7 @@
 package bio.terra.buffer.service.pool;
 
+import static bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator.MAX_LENGTH_GCP_PROJECT_ID_PREFIX;
+
 import bio.terra.buffer.common.exception.InvalidPoolConfigException;
 import bio.terra.buffer.generated.model.GcpProjectConfig;
 import bio.terra.buffer.generated.model.ResourceConfig;
@@ -20,6 +22,11 @@ public class GcpResourceConfigValidator implements ResourceConfigValidator {
         || gcpProjectConfig.getBillingAccount().isEmpty()) {
       throw new InvalidPoolConfigException(
           String.format("Missing billing account for config: %s", config.getConfigName()));
+    }
+    if (gcpProjectConfig.getProjectIdSchema().getPrefix().length()
+        > MAX_LENGTH_GCP_PROJECT_ID_PREFIX) {
+      throw new InvalidPoolConfigException(
+          String.format("Project id prefix is too long: %s", config.getConfigName()));
     }
   }
 }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateProjectStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateProjectStep.java
@@ -39,10 +39,6 @@ public class CreateProjectStep implements Step {
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);
     try {
-      // If the project id us used. Fail the flight and let Stairway rollback the flight.
-      if (retrieveProject(rmCow, projectId).isPresent()) {
-        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);
-      }
       Project project =
           new Project()
               .setProjectId(projectId)

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
@@ -41,7 +41,7 @@ public class GenerateProjectIdStep implements Step {
           CLOUD_RESOURCE_UID,
           new CloudResourceUid().googleProjectUid(new GoogleProjectUid().projectId(projectId)));
       return StepResult.getStepResultSuccess();
-    } catch (IOException ioEx) {
+    } catch (IOException | InterruptedException ioEx) {
       logger.info("Error when generating GCP project id.", ioEx);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ioEx);
     }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
@@ -2,6 +2,7 @@ package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.CLOUD_RESOURCE_UID;
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
+import static bio.terra.buffer.service.resource.flight.GoogleUtils.retrieveProject;
 
 import bio.terra.buffer.generated.model.CloudResourceUid;
 import bio.terra.buffer.generated.model.GcpProjectConfig;
@@ -35,15 +36,33 @@ public class GenerateProjectIdStep implements Step {
     FlightMap workingMap = flightContext.getWorkingMap();
     try {
       String projectId =
-          projectIdGenerator.generateIdWithRetries(gcpProjectConfig.getProjectIdSchema(), rmCow);
+          projectIdGenerator.generateIdWithRetries(gcpProjectConfig.getProjectIdSchema());
+
+      // check that a project with this id does not already exist. to do this check, we try
+      // to retrieve the project. this will only succeed if RBS has permission to get that
+      // project. we expect this to be the case most of the time because of the Terra-specific
+      // prefix, but it's possible this step will generate a project that is in use outside of
+      // Terra. in that case, the project creation step will fail.
+      if (retrieveProject(rmCow, projectId).isPresent()) {
+        logger.info("Generated GCP project is already in use: {}", projectId);
+
+        // here we use Stairway retry, instead of retrying immediately in order to rate limit
+        // the number of project get calls made per step execution. i.e. we could retry the
+        // project id generation immediately since we haven't hit a quota issue yet, but that
+        // would mean each execution of this step may make a variable number of project get
+        // calls. that would make it hard to decide how many flights could run in parallel
+        // without hitting project get quota issues.
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY);
+      }
+
       flightContext.getWorkingMap().put(GOOGLE_PROJECT_ID, projectId);
       workingMap.put(
           CLOUD_RESOURCE_UID,
           new CloudResourceUid().googleProjectUid(new GoogleProjectUid().projectId(projectId)));
       return StepResult.getStepResultSuccess();
-    } catch (IOException | InterruptedException ioEx) {
-      logger.info("Error when generating GCP project id.", ioEx);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ioEx);
+    } catch (IOException | InterruptedException ex) {
+      logger.info("Error when generating GCP project id.", ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
   }
 

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
@@ -9,9 +9,14 @@ import bio.terra.buffer.generated.model.GoogleProjectUid;
 import bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator;
 import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.stairway.*;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Generates Project Id and put it in working map. */
 public class GenerateProjectIdStep implements Step {
+  private final Logger logger = LoggerFactory.getLogger(GenerateProjectIdStep.class);
+
   private final GcpProjectConfig gcpProjectConfig;
   private final GcpProjectIdGenerator projectIdGenerator;
   private final CloudResourceManagerCow rmCow;
@@ -28,13 +33,18 @@ public class GenerateProjectIdStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) {
     FlightMap workingMap = flightContext.getWorkingMap();
-    String projectId =
-        projectIdGenerator.generateIdWithRetries(gcpProjectConfig.getProjectIdSchema(), rmCow);
-    flightContext.getWorkingMap().put(GOOGLE_PROJECT_ID, projectId);
-    workingMap.put(
-        CLOUD_RESOURCE_UID,
-        new CloudResourceUid().googleProjectUid(new GoogleProjectUid().projectId(projectId)));
-    return StepResult.getStepResultSuccess();
+    try {
+      String projectId =
+          projectIdGenerator.generateIdWithRetries(gcpProjectConfig.getProjectIdSchema(), rmCow);
+      flightContext.getWorkingMap().put(GOOGLE_PROJECT_ID, projectId);
+      workingMap.put(
+          CLOUD_RESOURCE_UID,
+          new CloudResourceUid().googleProjectUid(new GoogleProjectUid().projectId(projectId)));
+      return StepResult.getStepResultSuccess();
+    } catch (IOException ioEx) {
+      logger.info("Error when generating GCP project id.", ioEx);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ioEx);
+    }
   }
 
   @Override

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GenerateProjectIdStep.java
@@ -7,23 +7,29 @@ import bio.terra.buffer.generated.model.CloudResourceUid;
 import bio.terra.buffer.generated.model.GcpProjectConfig;
 import bio.terra.buffer.generated.model.GoogleProjectUid;
 import bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator;
+import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.stairway.*;
 
 /** Generates Project Id and put it in working map. */
 public class GenerateProjectIdStep implements Step {
   private final GcpProjectConfig gcpProjectConfig;
   private final GcpProjectIdGenerator projectIdGenerator;
+  private final CloudResourceManagerCow rmCow;
 
   public GenerateProjectIdStep(
-      GcpProjectConfig gcpProjectConfig, GcpProjectIdGenerator projectIdGenerator) {
+      GcpProjectConfig gcpProjectConfig,
+      GcpProjectIdGenerator projectIdGenerator,
+      CloudResourceManagerCow rmCow) {
     this.gcpProjectConfig = gcpProjectConfig;
     this.projectIdGenerator = projectIdGenerator;
+    this.rmCow = rmCow;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) {
     FlightMap workingMap = flightContext.getWorkingMap();
-    String projectId = projectIdGenerator.generateId(gcpProjectConfig.getProjectIdSchema());
+    String projectId =
+        projectIdGenerator.generateIdWithRetries(gcpProjectConfig.getProjectIdSchema(), rmCow);
     flightContext.getWorkingMap().put(GOOGLE_PROJECT_ID, projectId);
     workingMap.put(
         CLOUD_RESOURCE_UID,

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectCreationFlight.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectCreationFlight.java
@@ -44,7 +44,8 @@ public class GoogleProjectCreationFlight extends Flight {
     addStep(new AssertResourceCreatingStep(bufferDao), newInternalDefaultRetryRule());
     addStep(new UndoCreatingDbEntityStep(bufferDao), newInternalDefaultRetryRule());
     addStep(
-        new GenerateProjectIdStep(gcpProjectConfig, idGenerator), newCloudApiDefaultRetryRule());
+        new GenerateProjectIdStep(gcpProjectConfig, idGenerator, rmCow),
+        newCloudApiDefaultRetryRule());
     addStep(new CreateProjectStep(rmCow, gcpProjectConfig), newCloudApiDefaultRetryRule());
     addStep(new SetBillingInfoStep(billingCow, gcpProjectConfig), newCloudApiDefaultRetryRule());
     addStep(

--- a/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
+++ b/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
@@ -1,18 +1,26 @@
 package bio.terra.buffer.service.resource.projectid;
 
+import static bio.terra.buffer.service.resource.flight.GoogleUtils.retrieveProject;
+
 import bio.terra.buffer.generated.model.ProjectIdSchema;
+import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.Scanner;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /** Generates Project Id for GCP project from config. */
 @Component
 public class GcpProjectIdGenerator {
+  private final Logger logger = LoggerFactory.getLogger(GcpProjectIdGenerator.class);
+
   /**
    * The size of project when generating random characters. Choose size as 8 based on AoU's
    * historical experience, increase if 8 is not enough for a pool's naming.
@@ -22,10 +30,59 @@ public class GcpProjectIdGenerator {
   /** The largest number to use for random suffixes for adjective/noun project IDs. */
   @VisibleForTesting static final int RANDOM_SUFFIX_LIMIT = 10000;
 
+  /** The maximum allowed length for a GCP project id. */
+  private static final int MAX_LENGTH_GCP_PROJECT_ID = 30;
+
+  /** The maximum allowed length for a GCP project id prefix (e.g. "terra-"). */
+  public static final int MAX_LENGTH_GCP_PROJECT_ID_PREFIX = 12;
+
+  /**
+   * The maximum number of times to try generating a project id that has an allowable length and is
+   * not already in use.
+   */
+  private static final int MAX_RETRIES = 100;
+
+  /**
+   * Generate a GCP project id from the prefix and scheme.
+   *
+   * <p>Keep retrying the id generation until we find one that fits into the GCP project id length
+   * limit and is not already in use, or until we have retried the maximum number of times.
+   *
+   * <p>To check if a project is in use, this method tries to retrieve the project. This will only
+   * succeed if RBS has permission to get that project. We expect this to be the case most of the
+   * time because of the Terra-specific prefix, but it's possible this step will generate a project
+   * that is in use outside of Terra. In that case, the project creation step will fail.
+   *
+   * @param projectIdSchema prefix and naming scheme
+   * @param rmCow resource manager wrapper to retrieve the project
+   * @return generated project id (prefix + naming scheme)
+   */
+  public String generateIdWithRetries(
+      ProjectIdSchema projectIdSchema, CloudResourceManagerCow rmCow) {
+    for (int numTries = 0; numTries < MAX_RETRIES; numTries++) {
+      String projectId = generateId(projectIdSchema);
+      if (projectId.length() <= MAX_LENGTH_GCP_PROJECT_ID)
+        try {
+          if (retrieveProject(rmCow, projectId).isEmpty()) {
+            logger.info("Generated GCP project id after {} tries.", numTries);
+            return projectId;
+          } else {
+            logger.info("Generated GCP project is already in use: {}", projectId);
+          }
+        } catch (IOException ioEx) {
+          logger.info("Error when retrieving GCP project. Retrying project id generation.", ioEx);
+          continue;
+        }
+    }
+    throw new RuntimeException(
+        "No project id found after maximum number of retries: " + MAX_RETRIES);
+  }
+
+  @VisibleForTesting
   /**
    * Generates project Id from prefix and scheme.
    *
-   * <p>The output will be prefix + naming scheme. For now, we only support RANDOM_CHAR scheme.
+   * <p>The output will be prefix + naming scheme.
    */
   public String generateId(ProjectIdSchema projectIdSchema) {
     String generatedId = projectIdSchema.getPrefix();

--- a/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
+++ b/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
@@ -71,7 +71,6 @@ public class GcpProjectIdGenerator {
           }
         } catch (IOException ioEx) {
           logger.info("Error when retrieving GCP project. Retrying project id generation.", ioEx);
-          continue;
         }
     }
     throw new RuntimeException(

--- a/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
+++ b/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
@@ -60,9 +60,11 @@ public class GcpProjectIdGenerator {
    * @param rmCow resource manager wrapper to retrieve the project
    * @return generated project id (prefix + naming scheme)
    * @throws IOException if there is an error retrieving the project from GCP
+   * @throws InterruptedException if no project id is found after the maximum number of retries
    */
   public String generateIdWithRetries(
-      ProjectIdSchema projectIdSchema, CloudResourceManagerCow rmCow) throws IOException {
+      ProjectIdSchema projectIdSchema, CloudResourceManagerCow rmCow)
+      throws IOException, InterruptedException {
     for (int numTries = 0; numTries < MAX_RETRIES; numTries++) {
       String projectId = generateId(projectIdSchema);
       if (projectId.length() <= MAX_LENGTH_GCP_PROJECT_ID)
@@ -73,7 +75,7 @@ public class GcpProjectIdGenerator {
           logger.info("Generated GCP project is already in use: {}", projectId);
         }
     }
-    throw new RuntimeException(
+    throw new InterruptedException(
         "No project id found after maximum number of retries: " + MAX_RETRIES);
   }
 

--- a/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
+++ b/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
@@ -31,10 +31,7 @@ public class GcpProjectIdGenerator {
    */
   public static final int MAX_LENGTH_GCP_PROJECT_ID_PREFIX = 12;
 
-  /**
-   * The maximum number of times to try generating a project id that has an allowable length and is
-   * not already in use.
-   */
+  /** The maximum number of times to try generating a project id that has an allowable length. */
   private static final int MAX_RETRIES = 100;
 
   /**

--- a/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
+++ b/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
@@ -1,26 +1,18 @@
 package bio.terra.buffer.service.resource.projectid;
 
-import static bio.terra.buffer.service.resource.flight.GoogleUtils.retrieveProject;
-
 import bio.terra.buffer.generated.model.ProjectIdSchema;
-import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.Scanner;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /** Generates Project Id for GCP project from config. */
 @Component
 public class GcpProjectIdGenerator {
-  private final Logger logger = LoggerFactory.getLogger(GcpProjectIdGenerator.class);
-
   /**
    * The size of project when generating random characters. Choose size as 8 based on AoU's
    * historical experience, increase if 8 is not enough for a pool's naming.
@@ -49,31 +41,18 @@ public class GcpProjectIdGenerator {
    * Generate a GCP project id from the prefix and scheme.
    *
    * <p>Keep retrying the id generation until we find one that fits into the GCP project id length
-   * limit and is not already in use, or until we have retried the maximum number of times.
-   *
-   * <p>To check if a project is in use, this method tries to retrieve the project. This will only
-   * succeed if RBS has permission to get that project. We expect this to be the case most of the
-   * time because of the Terra-specific prefix, but it's possible this step will generate a project
-   * that is in use outside of Terra. In that case, the project creation step will fail.
+   * limit, or until we have retried the maximum number of times.
    *
    * @param projectIdSchema prefix and naming scheme
-   * @param rmCow resource manager wrapper to retrieve the project
    * @return generated project id (prefix + naming scheme)
-   * @throws IOException if there is an error retrieving the project from GCP
    * @throws InterruptedException if no project id is found after the maximum number of retries
    */
-  public String generateIdWithRetries(
-      ProjectIdSchema projectIdSchema, CloudResourceManagerCow rmCow)
-      throws IOException, InterruptedException {
+  public String generateIdWithRetries(ProjectIdSchema projectIdSchema) throws InterruptedException {
     for (int numTries = 0; numTries < MAX_RETRIES; numTries++) {
       String projectId = generateId(projectIdSchema);
-      if (projectId.length() <= MAX_LENGTH_GCP_PROJECT_ID)
-        if (retrieveProject(rmCow, projectId).isEmpty()) {
-          logger.info("Generated GCP project id after {} tries.", numTries);
-          return projectId;
-        } else {
-          logger.info("Generated GCP project is already in use: {}", projectId);
-        }
+      if (projectId.length() <= MAX_LENGTH_GCP_PROJECT_ID) {
+        return projectId;
+      }
     }
     throw new InterruptedException(
         "No project id found after maximum number of retries: " + MAX_RETRIES);

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -16,6 +16,9 @@ poolConfigs:
   - poolId: "workspace_manager_v8"
     size: 500
     resourceConfigName: "workspace_manager_v8"
+  - poolId: "workspace_manager_v9"
+    size: 500
+    resourceConfigName: "workspace_manager_v9"
   - poolId: "datarepo_v1"
     size: 500
     resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v9.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v9.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v9"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-t"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "375605435272" #test.firecloud.org/tools/buffer-tools/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -366,7 +366,7 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
           ((ApplicationContext) applicationContext).getBean(GcpProjectIdGenerator.class);
       addStep(new LatchStep());
       addStep(new UndoCreatingDbEntityStep(bufferDao));
-      addStep(new GenerateProjectIdStep(gcpProjectConfig, idGenerator));
+      addStep(new GenerateProjectIdStep(gcpProjectConfig, idGenerator, rmCow));
       addStep(new ErrorCreateProjectStep(rmCow, gcpProjectConfig));
       addStep(new FinishResourceCreationStep(bufferDao));
     }

--- a/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
+++ b/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
@@ -5,12 +5,16 @@ import static org.junit.jupiter.api.Assertions.*;
 import bio.terra.buffer.common.BaseUnitTest;
 import bio.terra.buffer.common.exception.InvalidPoolConfigException;
 import bio.terra.buffer.generated.model.GcpProjectConfig;
+import bio.terra.buffer.generated.model.ProjectIdSchema;
 import bio.terra.buffer.generated.model.ResourceConfig;
 import org.junit.jupiter.api.Test;
 
 public class ResourceConfigValidatorTest extends BaseUnitTest {
   private static GcpProjectConfig newValidGcpProjectConfig() {
-    return new GcpProjectConfig().billingAccount("123");
+    return new GcpProjectConfig()
+        .billingAccount("123")
+        .projectIdSchema(
+            new ProjectIdSchema().prefix("prefix").scheme(ProjectIdSchema.SchemeEnum.RANDOM_CHAR));
   }
 
   @Test
@@ -31,5 +35,26 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
             InvalidPoolConfigException.class,
             () -> new GcpResourceConfigValidator().validate(resourceConfig));
     assertTrue(exception.getMessage().contains("Missing billing account"));
+  }
+
+  @Test
+  public void testValidateGcpConfig_prefixTooLong() {
+    ResourceConfig resourceConfig =
+        new ResourceConfig()
+            .configName("testConfig")
+            .gcpProjectConfig(
+                newValidGcpProjectConfig()
+                    .projectIdSchema(
+                        new ProjectIdSchema()
+                            .prefix("prefixlongerthan12characters")
+                            .scheme(ProjectIdSchema.SchemeEnum.TWO_WORDS_NUMBER)));
+    InvalidPoolConfigException exception =
+        assertThrows(
+            InvalidPoolConfigException.class,
+            () -> new GcpResourceConfigValidator().validate(resourceConfig));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Project id prefix is too long for TWO_WORDS_NUMBER naming scheme"));
   }
 }


### PR DESCRIPTION
- Added length validation to the GCP project id generation. Check that the length is <= 30 ([ref](https://cloud.google.com/resource-manager/docs/creating-managing-projects#:~:text=A%20project%20ID%20must%20start,between%206%20and%2030%20characters.&text=You%20can't%20use%20certain,new%20project%20with%20the%20projects.)).
- Moved the check for whether the project id is already in use from the `CreateProjectStep` to the `GenerateProjectIdStep`, and try to generate another id if the generated one is already in use.
- Restricted the project id prefix length to 12 characters. This only applies when using the `TWO_WORDS_NUMBER` naming scheme. I chose 12 because on average we get a valid project id on the second try. Some prefixes will have to be shortened to meet this requirement (e.g. `terra-wsm-test` -> `terra-wsm-t`) Below are some statistics for the number of tries to get a valid project id with the given prefix length:

| Prefix Length | Mean | Max | 95 Percentile | 99 Percentile |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| 11 | 1 | 15 | 4 | 6 |
| 12 | 2 | 28 | 7 | 11 |
| 13 | 5 | 65 | 16 | 26 |
| 14 | 15 | 164 | 45 | 70 |
| 15 | 76 | 853 | 228 | 354 |
| 16 | 785 | 7507 | 2351 | 3629 |

- Added a new tools project pool for WSM personal environments that uses the `TWO_WORDS_NUMBER` naming scheme. `workspace_manager_v9` uses the prefix `terra-wsm-t` instead of the previous `terra-wsm-test` so that it meets the prefix length requirement.