### PR TITLE
PF-228 (part 2): Add new dev WSM pool with new naming scheme.

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -7,6 +7,9 @@ poolConfigs:
   - poolId: "workspace_manager_v8"
     size: 500
     resourceConfigName: "workspace_manager_v8"
+  - poolId: "workspace_manager_v9"
+    size: 500
+    resourceConfigName: "workspace_manager_v9"
   - poolId: "vpc_sc_v1"
     size: 300
     resourceConfigName: "vpc_sc_v1"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v9.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v9.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v9"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-d"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/test/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGeneratorTest.java
+++ b/src/test/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGeneratorTest.java
@@ -6,6 +6,7 @@ import static bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator.
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.buffer.common.BaseUnitTest;
@@ -30,5 +31,19 @@ public class GcpProjectIdGeneratorTest extends BaseUnitTest {
         new ProjectIdSchema().prefix("prefix").scheme(TWO_WORDS_NUMBER);
     String generatedID = gcpProjectIDGenerator.generateId(generatorConfig);
     assertThat(generatedID, matchesPattern("prefix-[a-z]+-[a-z]+-[0-9]+"));
+  }
+
+  @Test
+  public void generateIdWithRetries_retriesExhausted() {
+    ProjectIdSchema generatorConfig =
+        new ProjectIdSchema().prefix("prefixthatislongerthan30characters").scheme(TWO_WORDS_NUMBER);
+    InterruptedException interruptedException =
+        assertThrows(
+            InterruptedException.class,
+            () -> gcpProjectIDGenerator.generateIdWithRetries(generatorConfig));
+    assertTrue(
+        interruptedException
+            .getMessage()
+            .contains("No project id found after maximum number of retries"));
   }
 }


### PR DESCRIPTION
- Added a new dev WSM pool that uses the `TWO_WORDS_NUMBER` project naming scheme, and a shorter prefix than before (`terra-wsm-dev`->`terra-wsm-d`). There is already a tools WSM pool that I tested on my personal environment WSM deployment and confirmed that projects with the new naming scheme are returned when creating a new workspace.
- Added a unit test for when the maximum number of retries have been exhausted in generating a new project id.

I'm planning to remove the previous `workspace_manager_v8` pools in a follow-on PR once I move all the deployments over to using the new `workspace_manager_v9` pools.