### PR TITLE
[PF-924]Add private Google Access flag to controll whether to enable private Google Access

### DIFF
--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -45,9 +45,9 @@ public class CrlConfiguration {
   /** The client name required by CRL. */
   public static final String CLIENT_NAME = "terra-resource-buffer";
   /**
-   * How long to keep the resource before Janitor do the cleanup.
-   * Set to large number to avoid the conflict between Terra perf tesing with Janitor clean up jobs
-    */
+   * How long to keep the resource before Janitor do the cleanup. Set to large number to avoid the
+   * conflict between Terra perf tesing with Janitor clean up jobs
+   */
   public static final Duration TEST_RESOURCE_TIME_TO_LIVE = Duration.ofHours(10);
 
   /**

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateDnsZoneStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateDnsZoneStep.java
@@ -1,7 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
-import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.usePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
@@ -55,7 +55,7 @@ public class CreateDnsZoneStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);
-    if (!isUsePrivateGoogleAccess(gcpProjectConfig)) {
+    if (!usePrivateGoogleAccess(gcpProjectConfig)) {
       return StepResult.getStepResultSuccess();
     }
     try {

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateDnsZoneStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateDnsZoneStep.java
@@ -1,7 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
-import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isNetworkMonitoringEnabled;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
@@ -13,7 +13,9 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import com.google.api.services.compute.model.Network;
-import com.google.api.services.dns.model.*;
+import com.google.api.services.dns.model.ManagedZone;
+import com.google.api.services.dns.model.ManagedZonePrivateVisibilityConfig;
+import com.google.api.services.dns.model.ManagedZonePrivateVisibilityConfigNetwork;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -53,7 +55,7 @@ public class CreateDnsZoneStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);
-    if (!isNetworkMonitoringEnabled(gcpProjectConfig)) {
+    if (!isUsePrivateGoogleAccess(gcpProjectConfig)) {
       return StepResult.getStepResultSuccess();
     }
     try {

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateResourceRecordSetStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateResourceRecordSetStep.java
@@ -1,7 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
-import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isNetworkMonitoringEnabled;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
@@ -53,7 +53,7 @@ public class CreateResourceRecordSetStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);
-    if (!isNetworkMonitoringEnabled(gcpProjectConfig)) {
+    if (!isUsePrivateGoogleAccess(gcpProjectConfig)) {
       return StepResult.getStepResultSuccess();
     }
     try {

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateResourceRecordSetStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateResourceRecordSetStep.java
@@ -1,7 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
-import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.usePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
@@ -53,7 +53,7 @@ public class CreateResourceRecordSetStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);
-    if (!isUsePrivateGoogleAccess(gcpProjectConfig)) {
+    if (!usePrivateGoogleAccess(gcpProjectConfig)) {
       return StepResult.getStepResultSuccess();
     }
     try {

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateRouteStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateRouteStep.java
@@ -1,7 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
-import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isNetworkMonitoringEnabled;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
@@ -49,7 +49,7 @@ public class CreateRouteStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
-    if (!isNetworkMonitoringEnabled(gcpProjectConfig)) {
+    if (!isUsePrivateGoogleAccess(gcpProjectConfig)) {
       return StepResult.getStepResultSuccess();
     }
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateRouteStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateRouteStep.java
@@ -1,7 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
-import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.usePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
@@ -49,7 +49,7 @@ public class CreateRouteStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
-    if (!isUsePrivateGoogleAccess(gcpProjectConfig)) {
+    if (!usePrivateGoogleAccess(gcpProjectConfig)) {
       return StepResult.getStepResultSuccess();
     }
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
@@ -2,6 +2,7 @@ package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
 import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isNetworkMonitoringEnabled;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.NETWORK_NAME;
 
@@ -120,7 +121,7 @@ public class CreateSubnetsStep implements Step {
                 .setNetwork(network.getSelfLink())
                 .setIpCidrRange(entry.getValue())
                 .setEnableFlowLogs(networkMonitoringEnabled)
-                .setPrivateIpGoogleAccess(networkMonitoringEnabled);
+                .setPrivateIpGoogleAccess(isUsePrivateGoogleAccess(gcpProjectConfig));
         if (networkMonitoringEnabled) {
           subnetwork.setLogConfig(LOG_CONFIG);
         }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
@@ -2,7 +2,7 @@ package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
 import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isNetworkMonitoringEnabled;
-import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.isUsePrivateGoogleAccess;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.usePrivateGoogleAccess;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.*;
 import static bio.terra.buffer.service.resource.flight.GoogleUtils.NETWORK_NAME;
 
@@ -121,7 +121,7 @@ public class CreateSubnetsStep implements Step {
                 .setNetwork(network.getSelfLink())
                 .setIpCidrRange(entry.getValue())
                 .setEnableFlowLogs(networkMonitoringEnabled)
-                .setPrivateIpGoogleAccess(isUsePrivateGoogleAccess(gcpProjectConfig));
+                .setPrivateIpGoogleAccess(usePrivateGoogleAccess(gcpProjectConfig));
         if (networkMonitoringEnabled) {
           subnetwork.setLogConfig(LOG_CONFIG);
         }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -35,8 +35,9 @@ public class GoogleProjectConfigUtils {
    * true regardless.
    */
   public static boolean isUsePrivateGoogleAccess(GcpProjectConfig gcpProjectConfig) {
-    return isNetworkMonitoringEnabled(gcpProjectConfig) || (gcpProjectConfig.getNetwork() != null
-        && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess() != null
-        && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess());
+    return isNetworkMonitoringEnabled(gcpProjectConfig)
+        || (gcpProjectConfig.getNetwork() != null
+            && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess() != null
+            && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess());
   }
 }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -29,10 +29,14 @@ public class GoogleProjectConfigUtils {
         && gcpProjectConfig.getComputeEngine().isKeepDefaultServiceAcct();
   }
 
-  /** Checks if private Google Access enabled. */
+  /**
+   * Checks if private Google Access enabled. Using network monitoring requires private Google
+   * Access. So if {@link #isNetworkMonitoringEnabled(GcpProjectConfig)} is true, this will also be
+   * true regardless.
+   */
   public static boolean isUsePrivateGoogleAccess(GcpProjectConfig gcpProjectConfig) {
-    return gcpProjectConfig.getNetwork() != null
+    return isNetworkMonitoringEnabled(gcpProjectConfig) || (gcpProjectConfig.getNetwork() != null
         && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess() != null
-        && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess();
+        && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess());
   }
 }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -34,10 +34,10 @@ public class GoogleProjectConfigUtils {
    * Access. So if {@link #isNetworkMonitoringEnabled(GcpProjectConfig)} is true, this will also be
    * true regardless.
    */
-  public static boolean isUsePrivateGoogleAccess(GcpProjectConfig gcpProjectConfig) {
+  public static boolean usePrivateGoogleAccess(GcpProjectConfig gcpProjectConfig) {
     return isNetworkMonitoringEnabled(gcpProjectConfig)
         || (gcpProjectConfig.getNetwork() != null
-            && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess() != null
-            && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess());
+            && gcpProjectConfig.getNetwork().isEnablePrivateGoogleAccess() != null
+            && gcpProjectConfig.getNetwork().isEnablePrivateGoogleAccess());
   }
 }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -28,4 +28,11 @@ public class GoogleProjectConfigUtils {
         && gcpProjectConfig.getComputeEngine().isKeepDefaultServiceAcct() != null
         && gcpProjectConfig.getComputeEngine().isKeepDefaultServiceAcct();
   }
+
+  /** Checks if private Google Access enabled. */
+  public static boolean isUsePrivateGoogleAccess(GcpProjectConfig gcpProjectConfig) {
+    return gcpProjectConfig.getNetwork() != null
+        && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess() != null
+        && gcpProjectConfig.getNetwork().isUsePrivateGoogleAccess();
+  }
 }

--- a/src/main/resources/config/resource_schema.yaml
+++ b/src/main/resources/config/resource_schema.yaml
@@ -101,6 +101,8 @@ components:
           description: |-
             Make network traffic is measured. If enabled, turn on flow logs, enable private google access.
             See https://docs.google.com/document/d/1ccz2kzDL68CPofZ-b95ykQIudCgh7OCSFJ4Ym4Oz0r0/edit for more context.
+            Note: Having NetworkMonitoring requires usePrivateGoogleAccess to be true. So usePrivateGoogleAccess will be true
+            if this is set to true
           type: boolean
         keepDefaultNetwork:
           description: |-

--- a/src/main/resources/config/resource_schema.yaml
+++ b/src/main/resources/config/resource_schema.yaml
@@ -107,6 +107,11 @@ components:
             Keep the default VPC network if this flag is true, otherwise delete it.
           type: boolean
           default: false
+        usePrivateGoogleAccess:
+          description: |-
+            Whether to config Private Google Access See: https://cloud.google.com/vpc/docs/configure-private-google-access
+          type: boolean
+          default: false
       type: object
 
     ComputeEngine:

--- a/src/main/resources/config/resource_schema.yaml
+++ b/src/main/resources/config/resource_schema.yaml
@@ -102,16 +102,19 @@ components:
             Make network traffic is measured. If enabled, turn on flow logs, enable private google access.
             See https://docs.google.com/document/d/1ccz2kzDL68CPofZ-b95ykQIudCgh7OCSFJ4Ym4Oz0r0/edit for more context.
             Note: Having NetworkMonitoring requires usePrivateGoogleAccess to be true. So usePrivateGoogleAccess will be true
-            if this is set to true
+            if this is set to true.
           type: boolean
+          default: false
         keepDefaultNetwork:
           description: |-
             Keep the default VPC network if this flag is true, otherwise delete it.
           type: boolean
           default: false
-        usePrivateGoogleAccess:
+        enablePrivateGoogleAccess:
           description: |-
             Whether to config Private Google Access See: https://cloud.google.com/vpc/docs/configure-private-google-access
+            Note: Having NetworkMonitoring requires usePrivateGoogleAccess to be true. So usePrivateGoogleAccess will be true
+            if this is set to true.
           type: boolean
           default: false
       type: object

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -167,7 +167,7 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateGoogleProject_enableNetworkMonitoring() throws Exception {
+  public void testCreateGoogleProject_enablePrivateGoogleAccessAndFlowLog() throws Exception {
     FlightManager manager =
         new FlightManager(
             bufferDao, flightSubmissionFactoryImpl, stairwayComponent, transactionTemplate);
@@ -176,7 +176,9 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
             bufferDao,
             newBasicGcpConfig()
                 .network(
-                    new bio.terra.buffer.generated.model.Network().enableNetworkMonitoring(true)));
+                    new bio.terra.buffer.generated.model.Network()
+                        .enableNetworkMonitoring(true)
+                        .usePrivateGoogleAccess(true)));
 
     String flightId = manager.submitCreationFlight(pool).get();
     ResourceId resourceId =

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -178,7 +178,7 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
                 .network(
                     new bio.terra.buffer.generated.model.Network()
                         .enableNetworkMonitoring(true)
-                        .usePrivateGoogleAccess(true)));
+                        .enablePrivateGoogleAccess(true)));
 
     String flightId = manager.submitCreationFlight(pool).get();
     ResourceId resourceId =

--- a/src/test/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtilsTest.java
+++ b/src/test/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtilsTest.java
@@ -1,0 +1,22 @@
+package bio.terra.buffer.service.resource.flight;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.buffer.common.BaseUnitTest;
+import bio.terra.buffer.generated.model.GcpProjectConfig;
+import bio.terra.buffer.generated.model.Network;
+import org.junit.jupiter.api.Test;
+
+public class GoogleProjectConfigUtilsTest extends BaseUnitTest {
+
+  @Test
+  public void userPrivateGoogleAccess() throws Exception {
+    GcpProjectConfig gcpProjectConfig =
+        new GcpProjectConfig().network(new Network().enablePrivateGoogleAccess(false));
+    assertFalse(GoogleProjectConfigUtils.usePrivateGoogleAccess(gcpProjectConfig));
+
+    gcpProjectConfig.setNetwork(gcpProjectConfig.getNetwork().enableNetworkMonitoring(true));
+    assertTrue(GoogleProjectConfigUtils.usePrivateGoogleAccess(gcpProjectConfig));
+  }
+}


### PR DESCRIPTION
Background: When RBS is designed, private Google Access + Flow logs is just used by AoU, so we combined them into enableNetworkMonitroring. 
But with the new Cromwell requirements, it wants all CWB projects having private Google Access Enabled but disable flow logs.
So I split them back to two.
If private Google Access is true, we will:

1. Set this value in Subnets
2.  Create private DNS record
3. Record sets
4. Create Custom static Route.
All steps is https://cloud.google.com/vpc/docs/configure-private-google-access
And https://github.com/broadinstitute/gcp-dm-templates/blob/bf2ec422869d108670ea34f93db3e19d5d07b017/firecloud_project.py 