### PR TITLE
DDO-1319 Update local dev workflow for buffer to use render

### DIFF
--- a/local-dev/setup_gke_deploy.sh
+++ b/local-dev/setup_gke_deploy.sh
@@ -9,19 +9,33 @@ set -e
 # Required input
 ENV=$1
 # Optional input
-TERRA_HELM_BRANCH=${2:-master}
-TERRA_HELMFILE_BRANCH=${3:-master}
+TERRA_HELMFILE_BRANCH=${2:-master}
+GIT_PROTOCOL=${3:-http}
+
+if [ "$GIT_PROTOCOL" = "http" ]; then
+    helmfilegit=https://github.com/broadinstitute/terra-helmfile
+else
+    helmfilegit=git@github.com:broadinstitute/terra-helmfile.git
+fi
 
 # Clone Helm chart and helmfile repos
-rm -rf terra-helm
 rm -rf terra-helmfile
-git clone -b "$TERRA_HELM_BRANCH" --single-branch https://github.com/broadinstitute/terra-helm.git
-git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch https://github.com/broadinstitute/terra-helmfile.git
+git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch "${helmfilegit}"
 
 # Template in environment
 sed "s|ENV|${ENV}|g" skaffold.yaml.template > skaffold.yaml
 sed "s|ENV|${ENV}|g" values.yaml.template > values.yaml
 
+# Render manifests to terra-helmfile/output/ directory.
+#
+# Unfortunately we need to render them all into a single mega-file
+# because Skaffold's `kubectl` deployment does not support
+# recursive globbing like "output/manifests/**/*.yaml"
+mkdir -p ./terra-helmfile/output
+./terra-helmfile/bin/render \
+  -e "${ENV}" \
+  -a buffer \
+  --stdout > terra-helmfile/output/manifests.yaml
 
 # That's it! You can now deploy to the k8s cluster by running
 # $ skaffold run

--- a/local-dev/setup_gke_deploy.sh
+++ b/local-dev/setup_gke_deploy.sh
@@ -35,6 +35,7 @@ mkdir -p ./terra-helmfile/output
 ./terra-helmfile/bin/render \
   -e "${ENV}" \
   -a buffer \
+  --values-file ./values.yaml \
   --stdout > terra-helmfile/output/manifests.yaml
 
 # That's it! You can now deploy to the k8s cluster by running

--- a/local-dev/skaffold.yaml.template
+++ b/local-dev/skaffold.yaml.template
@@ -1,5 +1,5 @@
 #This is a Skaffold configuration, which lets developers continuously push new images to their development namespaces.
-apiVersion: skaffold/v2alpha4
+apiVersion: skaffold/v2beta17
 kind: Config
 build:
   artifacts:
@@ -8,16 +8,7 @@ build:
     jib: {}
 deploy:
   statusCheckDeadlineSeconds: 540
-  helm:
-    releases:
-      - name: buffer-ENV
-        namespace: terra-ENV
-        chartPath: terra-helm/charts/buffer
-        skipBuildDependencies: true
-        values:
-          image: gcr.io/terra-kernel-k8s/terra-resource-buffer
-        valuesFiles:
-          - terra-helmfile/terra/values/buffer.yaml
-          - terra-helmfile/terra/values/buffer/personal.yaml
-          - terra-helmfile/terra/values/buffer/personal/ENV.yaml
-          - values.yaml
+  kubectl:
+    manifests:
+    - terra-helmfile/output/manifests.yaml
+    defaultNamespace: terra-ENV


### PR DESCRIPTION
DevOps is preparing to make some structural changes to the terra-helmfile repo; this PR updates buffer's Skaffold development workflow to be resilient to those changes. Changes include:
* Remove references to `terra-helm`
* Render manifests using `terra-helmfile`'s `render` tool instead of invoking `helm` with hardcoded values file paths
* Use Skaffold's kubectl deployment option to deploy these rendered manifests

I have tested these changes by deploying buffer to the `gmalkov` personal environment.