### PR TITLE
[RW-7587][risk=no]: Add flow log filter that filter out inter-VPC network traffic 

### DIFF
--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
@@ -46,6 +46,12 @@ import org.slf4j.LoggerFactory;
  */
 public class CreateSubnetsStep implements Step {
   /**
+   * The log filter when network monitoring is enabled. We use flow logs to monitor network traffic
+   * that flys between VPC network and public internet. Filter out the logs if the traffic is within
+   * the smae VPC network.
+   */
+  private static final String LOG_FILTER = "src_instance.project_id != dest_instance.project_id";
+  /**
    * All current Google Compute Engine regions with the default Ip ranges listed (and manually
    * copied) in: https://cloud.google.com/vpc/docs/vpc#ip-ranges.
    */
@@ -92,6 +98,7 @@ public class CreateSubnetsStep implements Step {
   public static final SubnetworkLogConfig LOG_CONFIG =
       new SubnetworkLogConfig()
           .setAggregationInterval("INTERVAL_30_SEC")
+          .setFilterExpr(LOG_FILTER)
           .setEnable(true)
           .setFlowSampling((float) 1.0)
           .setMetadata("INCLUDE_ALL_METADATA");

--- a/src/main/resources/config/alpha/pool_schema.yml
+++ b/src/main/resources/config/alpha/pool_schema.yml
@@ -1,18 +1,15 @@
 # Resource Buffer Service Pools Schema in alpha environment
 ---
 poolConfigs:
-- poolId: "cwb_ws_alpha_v3"
-  size: 100
-  resourceConfigName: "cwb_ws_resource_alpha_v3"
 - poolId: "cwb_ws_alpha_v4"
   size: 100
   resourceConfigName: "cwb_ws_resource_alpha_v4"
-- poolId: "vpc_sc_v2"
-  size: 100
-  resourceConfigName: "vpc_sc_v2"
 - poolId: "vpc_sc_v3"
   size: 100
   resourceConfigName: "vpc_sc_v3"
+- poolId: "vpc_sc_v4"
+  size: 100
+  resourceConfigName: "vpc_sc_v4"
 - poolId: "datarepo_v1"
   size: 300
   resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/alpha/resource-config/vpc_sc_v4.yml
+++ b/src/main/resources/config/alpha/resource-config/vpc_sc_v4.yml
@@ -1,0 +1,35 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_v4"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-alpha"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/alpha/for_vpc_sc_unclaimed
+  parentFolderId: "38455243798"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "genomics.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -1,21 +1,18 @@
 # Resource Buffer Service Pools Schema in dev environment
 ---
 poolConfigs:
-  - poolId: "cwb_ws_dev_v3"
-    size: 300
-    resourceConfigName: "cwb_ws_resource_dev_v3"
   - poolId: "cwb_ws_dev_v4"
     size: 300
     resourceConfigName: "cwb_ws_resource_dev_v4"
   - poolId: "workspace_manager_v9"
     size: 500
     resourceConfigName: "workspace_manager_v9"
-  - poolId: "vpc_sc_v2"
-    size: 300
-    resourceConfigName: "vpc_sc_v2"
   - poolId: "vpc_sc_v3"
     size: 300
     resourceConfigName: "vpc_sc_v3"
+  - poolId: "vpc_sc_v4"
+    size: 300
+    resourceConfigName: "vpc_sc_v4"
   - poolId: "datarepo_v3"
     size: 300
     resourceConfigName: "datarepo_v3"

--- a/src/main/resources/config/dev/resource-config/vpc_sc_v4.yml
+++ b/src/main/resources/config/dev/resource-config/vpc_sc_v4.yml
@@ -1,0 +1,35 @@
+# # Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v4"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-dev"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/dev/for_vpc_sc_unclaimed
+  parentFolderId: "1061905712535"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/perf/pool_schema.yml
+++ b/src/main/resources/config/perf/pool_schema.yml
@@ -4,18 +4,15 @@ poolConfigs:
   - poolId: "workspace_manager_v5"
     size: 20
     resourceConfigName: "workspace_manager_v5"
-  - poolId: "cwb_ws_perf_v3"
-    size: 500
-    resourceConfigName: "cwb_ws_perf_v3"
   - poolId: "cwb_ws_perf_v4"
     size: 500
     resourceConfigName: "cwb_ws_perf_v4"
-  - poolId: "vpc_sc_v3"
-    size: 500
-    resourceConfigName: "vpc_sc_v3"
   - poolId: "vpc_sc_v4"
     size: 500
     resourceConfigName: "vpc_sc_v4"
+  - poolId: "vpc_sc_v5"
+    size: 500
+    resourceConfigName: "vpc_sc_v5"
   - poolId: "datarepo_v1"
     size: 300
     resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/perf/resource-config/vpc_sc_v5.yml
+++ b/src/main/resources/config/perf/resource-config/vpc_sc_v5.yml
@@ -1,0 +1,35 @@
+# Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v5"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-perf"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/perf/for_vpc_sc_unclaimed
+  parentFolderId: "533417334224"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/prod/pool_schema.yml
+++ b/src/main/resources/config/prod/pool_schema.yml
@@ -10,15 +10,12 @@ poolConfigs:
   - poolId: "cwb_ws_prod_v4"
     size: 3000
     resourceConfigName: "cwb_ws_prod_v4"
-  - poolId: "vpc_sc_v2"
-    size: 1000
-    resourceConfigName: "vpc_sc_v2"
-  - poolId: "vpc_sc_v3"
-    size: 1000
-    resourceConfigName: "vpc_sc_v3"
   - poolId: "vpc_sc_v4"
     size: 1000
     resourceConfigName: "vpc_sc_v4"
+  - poolId: "vpc_sc_v5"
+    size: 1000
+    resourceConfigName: "vpc_sc_v5"
   - poolId: "datarepo_v1"
     size: 1000
     resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/prod/resource-config/vpc_sc_v5.yml
+++ b/src/main/resources/config/prod/resource-config/vpc_sc_v5.yml
@@ -1,0 +1,33 @@
+# Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v5"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc"
+    scheme: "RANDOM_CHAR"
+  # firecloud.org/prod/for_vpc_sc_unclaimed
+  parentFolderId: "160283235721"
+  billingAccount: "0106B0-41CAA9-427C96"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/staging/pool_schema.yml
+++ b/src/main/resources/config/staging/pool_schema.yml
@@ -13,6 +13,9 @@ poolConfigs:
 - poolId: "vpc_sc_v3"
   size: 100
   resourceConfigName: "vpc_sc_v3"
+- poolId: "vpc_sc_v4"
+  size: 100
+  resourceConfigName: "vpc_sc_v4"
 - poolId: "datarepo_v1"
   size: 300
   resourceConfigName: "datarepo_v1"

--- a/src/main/resources/config/staging/resource-config/vpc_sc_v4.yml
+++ b/src/main/resources/config/staging/resource-config/vpc_sc_v4.yml
@@ -1,0 +1,35 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_v4"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-staging"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/staging/for_vpc_sc_unclaimed
+  parentFolderId: "119547684332"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "genomics.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -1,30 +1,21 @@
 # RBS Pools Schema in tools environment
 ---
 poolConfigs:
-  - poolId: "cwb_ws_fiab_v3"
-    size: 500
-    resourceConfigName: "cwb_ws_resource_fiab_v3"
   - poolId: "cwb_ws_fiab_v4"
     size: 500
     resourceConfigName: "cwb_ws_resource_fiab_v4"
-  - poolId: "vpc_sc_dev-fiab_v2"
+  - poolId: "vpc_sc_dev-fiab_v4"
     size: 100
-    resourceConfigName: "vpc_sc_dev-fiab_v2"
-  - poolId: "vpc_sc_dev-fiab_v3"
-    size: 100
-    resourceConfigName: "vpc_sc_dev-fiab_v3"
-  - poolId: "cwb_ws_quality_v3"
-    size: 5000
-    resourceConfigName: "cwb_ws_resource_quality_v3"
+    resourceConfigName: "vpc_sc_dev-fiab_v4"
   - poolId: "cwb_ws_quality_v4"
     size: 5000
     resourceConfigName: "cwb_ws_resource_quality_v4"
-  - poolId: "vpc_sc_qa-fiab_v2"
-    size: 100
-    resourceConfigName: "vpc_sc_qa-fiab_v2"
   - poolId: "vpc_sc_qa-fiab_v3"
     size: 100
     resourceConfigName: "vpc_sc_qa-fiab_v3"
+  - poolId: "vpc_sc_qa-fiab_v4"
+    size: 100
+    resourceConfigName: "vpc_sc_qa-fiab_v4"
   - poolId: "workspace_manager_v9"
     size: 500
     resourceConfigName: "workspace_manager_v9"

--- a/src/main/resources/config/tools/resource-config/vpc_sc_dev-fiab_v4.yml
+++ b/src/main/resources/config/tools/resource-config/vpc_sc_dev-fiab_v4.yml
@@ -1,0 +1,35 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_dev-fiab_v4"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-devfiab"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/tools/for_vpc_sc_unclaimed
+  parentFolderId: "610557500976"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v4.yml
+++ b/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v4.yml
@@ -1,0 +1,35 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_qa-fiab_v4"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-qafiab"
+    scheme: "RANDOM_CHAR"
+  # quality.firecloud.org/quality/for_vpc_sc_unclaimed
+  parentFolderId: "108325210767"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"


### PR DESCRIPTION
Background context: We are seeing increase cost when using dataproc. And it turns out caused by flow log cost.
I think master node and worker nodes communicates a lot hence generates lot of flow logs.
This PR filter out those logs that generated within VPC-SC. 
