### PR TITLE
[PF-1022] make log bucket creation configurable

### DIFF
--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateStorageLogBucketStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateStorageLogBucketStep.java
@@ -51,7 +51,7 @@ public class CreateStorageLogBucketStep implements Step {
     StorageCow storageCow =
         new StorageCow(clientConfig, StorageOptions.newBuilder().setProjectId(projectId).build());
     String bucketName = "storage-logs-" + projectId;
-    if (storageCow.get(bucketName) != null || !createLogBucket(gcpProjectConfig)) {
+    if (!createLogBucket(gcpProjectConfig) || storageCow.get(bucketName) != null) {
       return StepResult.getStepResultSuccess();
     }
     storageCow.create(

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateStorageLogBucketStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateStorageLogBucketStep.java
@@ -47,11 +47,15 @@ public class CreateStorageLogBucketStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext flightContext) {
+    if (!createLogBucket(gcpProjectConfig)) {
+      logger.info("Skipping log bucket creation due to configuration parameter.");
+      return StepResult.getStepResultSuccess();
+    }
     String projectId = flightContext.getWorkingMap().get(GOOGLE_PROJECT_ID, String.class);
     StorageCow storageCow =
         new StorageCow(clientConfig, StorageOptions.newBuilder().setProjectId(projectId).build());
     String bucketName = "storage-logs-" + projectId;
-    if (!createLogBucket(gcpProjectConfig) || storageCow.get(bucketName) != null) {
+    if (storageCow.get(bucketName) != null) {
       return StepResult.getStepResultSuccess();
     }
     storageCow.create(

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateStorageLogBucketStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateStorageLogBucketStep.java
@@ -1,6 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import static bio.terra.buffer.service.resource.FlightMapKeys.GOOGLE_PROJECT_ID;
+import static bio.terra.buffer.service.resource.flight.GoogleProjectConfigUtils.createLogBucket;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
 import bio.terra.cloudres.common.ClientConfig;
@@ -50,7 +51,7 @@ public class CreateStorageLogBucketStep implements Step {
     StorageCow storageCow =
         new StorageCow(clientConfig, StorageOptions.newBuilder().setProjectId(projectId).build());
     String bucketName = "storage-logs-" + projectId;
-    if (storageCow.get(bucketName) != null) {
+    if (storageCow.get(bucketName) != null || !createLogBucket(gcpProjectConfig)) {
       return StepResult.getStepResultSuccess();
     }
     storageCow.create(

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -57,6 +57,7 @@ public class GoogleProjectConfigUtils {
         && gcpProjectConfig.getNetwork().isBlockBatchInternetAccess();
   }
 
+  /** Create the GCS bucket for log storage if enabled in configuration. */
   public static boolean createLogBucket(GcpProjectConfig gcpProjectConfig) {
     return Optional.ofNullable(gcpProjectConfig.getStorage())
         .map(Storage::isCreateLogBucket) // returns Optional.empty() if null

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -1,7 +1,6 @@
 package bio.terra.buffer.service.resource.flight;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
-import bio.terra.buffer.generated.model.PoolConfig;
 
 /** Utility methods for parsing the Google Project configuration. */
 public class GoogleProjectConfigUtils {

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.buffer.service.resource.flight;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
+import bio.terra.buffer.generated.model.PoolConfig;
 
 /** Utility methods for parsing the Google Project configuration. */
 public class GoogleProjectConfigUtils {
@@ -53,5 +54,11 @@ public class GoogleProjectConfigUtils {
     return gcpProjectConfig.getNetwork() != null
         && gcpProjectConfig.getNetwork().isBlockBatchInternetAccess() != null
         && gcpProjectConfig.getNetwork().isBlockBatchInternetAccess();
+  }
+
+  public static boolean createLogBucket(GcpProjectConfig gcpProjectConfig) {
+    return gcpProjectConfig.getStorage() != null
+        && gcpProjectConfig.getStorage().isCreateLogBucket() != null
+        && gcpProjectConfig.getStorage().isCreateLogBucket();
   }
 }

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -1,6 +1,8 @@
 package bio.terra.buffer.service.resource.flight;
 
 import bio.terra.buffer.generated.model.GcpProjectConfig;
+import bio.terra.buffer.generated.model.Storage;
+import java.util.Optional;
 
 /** Utility methods for parsing the Google Project configuration. */
 public class GoogleProjectConfigUtils {
@@ -56,8 +58,8 @@ public class GoogleProjectConfigUtils {
   }
 
   public static boolean createLogBucket(GcpProjectConfig gcpProjectConfig) {
-    return gcpProjectConfig.getStorage() != null
-        && gcpProjectConfig.getStorage().isCreateLogBucket() != null
-        && gcpProjectConfig.getStorage().isCreateLogBucket();
+    return Optional.ofNullable(gcpProjectConfig.getStorage())
+        .map(Storage::isCreateLogBucket) // returns Optional.empty() if null
+        .orElse(true);
   }
 }

--- a/src/main/resources/config/resource_schema.yaml
+++ b/src/main/resources/config/resource_schema.yaml
@@ -149,7 +149,7 @@ components:
       properties:
         createLogBucket:
           description: |-
-            Create a bucket for logging (not UBLA-compliant).
+            Create a bucket for logging (object-level access enabled).
           type: boolean
           default: true
       type: object

--- a/src/main/resources/config/resource_schema.yaml
+++ b/src/main/resources/config/resource_schema.yaml
@@ -60,6 +60,8 @@ components:
           $ref: '#/components/schemas/Network'
         computeEngine:
           $ref: '#/components/schemas/ComputeEngine'
+        storage:
+          $ref: '#/components/schemas/Storage'
       type: object
 
     ProjectIdSchema:
@@ -140,4 +142,14 @@ components:
             Keep the default Compute Engine service account if this flag is true, otherwise delete it.
           type: boolean
           default: false
+      type: object
+
+    Storage:
+      description: Google Cloud Storage used by the project
+      properties:
+        createLogBucket:
+          description: |-
+            Create a bucket for logging (not UBLA-compliant).
+          type: boolean
+          default: true
       type: object

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -57,6 +57,7 @@ import static bio.terra.buffer.service.resource.flight.GoogleUtils.resourceExist
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -278,6 +279,21 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
     assertFirewallRulesExist(project);
     assertDefaultVpcExists(project);
     assertFirewallRulesExistForDefaultVpc(project);
+  }
+
+  @Test
+  public void testCreateGoogleProject_createLogBucket_true() throws Exception {
+    FlightManager manager =
+        new FlightManager(
+            bufferDao, flightSubmissionFactoryImpl, stairwayComponent, transactionTemplate);
+    Pool pool = preparePool(bufferDao, newBasicGcpConfig());
+    String flightId = manager.submitCreationFlight(pool).get();
+    ResourceId resourceId =
+        extractResourceIdFromFlightState(blockUntilFlightComplete(stairwayComponent, flightId));
+    Project project = assertProjectExists(resourceId);
+    String projectId = project.getProjectId();
+    String logBucketName = "storage-logs-" + projectId;
+    assertNotNull(storageCow.get(logBucketName));
   }
 
   @Test

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -171,6 +171,9 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
     assertDnsNotExists(project);
     assertDefaultVpcNotExists(project);
     assertDefaultServiceAccountNotExists(project);
+
+    String logBucketName = "storage-logs-" + project.getProjectId();
+    assertNotNull(storageCow.get(logBucketName));
   }
 
   @Test
@@ -279,21 +282,6 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
     assertFirewallRulesExist(project);
     assertDefaultVpcExists(project);
     assertFirewallRulesExistForDefaultVpc(project);
-  }
-
-  @Test
-  public void testCreateGoogleProject_createLogBucket_true() throws Exception {
-    FlightManager manager =
-        new FlightManager(
-            bufferDao, flightSubmissionFactoryImpl, stairwayComponent, transactionTemplate);
-    Pool pool = preparePool(bufferDao, newBasicGcpConfig());
-    String flightId = manager.submitCreationFlight(pool).get();
-    ResourceId resourceId =
-        extractResourceIdFromFlightState(blockUntilFlightComplete(stairwayComponent, flightId));
-    Project project = assertProjectExists(resourceId);
-    String projectId = project.getProjectId();
-    String logBucketName = "storage-logs-" + projectId;
-    assertNotNull(storageCow.get(logBucketName));
   }
 
   @Test


### PR DESCRIPTION
The log bucket created uses object-level ACLs, and this doesn't satisfy the UBLA security rule. This change adds a Storage configuration group with a single entry for `createLogBucket`.