### PR TITLE
[PF-1278] Allow customize test resource time to live per env

### DIFF
--- a/local-dev/run_local.sh
+++ b/local-dev/run_local.sh
@@ -12,6 +12,7 @@ export BUFFER_CRL_TESTING_MODE=true
 export BUFFER_CRL_JANITOR_CLIENT_CREDENTIAL_FILE_PATH="$(dirname $0)"/../src/test/resources/rendered/janitor-client-sa-account.json
 export BUFFER_CRL_JANITOR_TRACK_RESOURCE_PROJECT_ID=terra-kernel-k8s
 export BUFFER_CRL_JANITOR_TRACK_RESOURCE_TOPIC_ID=crljanitor-tools-pubsub-topic
+export BUFFER_CRL_TEST_RESOURCE_TIME_TO_LIVE=1h
 export BUFFER_POOL_CONFIG_PATH=config/toolsalpha
 export SPRING_PROFILES_INCLUDE=human-readable-logging
 export TERRA_COMMON_STAIRWAY_FORCE_CLEAN_START=true

--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -45,12 +45,6 @@ public class CrlConfiguration {
   /** The client name required by CRL. */
   public static final String CLIENT_NAME = "terra-resource-buffer";
   /**
-   * How long to keep the resource before Janitor do the cleanup. Set to large number(5 days + 10
-   * hrs) to avoid the conflict between Terra perf tesing with Janitor clean up jobs.
-   */
-  public static final Duration TEST_RESOURCE_TIME_TO_LIVE = Duration.ofHours(130);
-
-  /**
    * Whether we're running Resource Buffer Service in test mode with Cloud Resource Library. If so,
    * we enable to the Janitor to auto-delete all created cloud resources.
    */
@@ -75,6 +69,14 @@ public class CrlConfiguration {
 
   /** pubsub topic id to publish track resource to Janitor */
   private String janitorTrackResourceTopicId;
+
+  /**
+   * How long to keep the resource before Janitor do the cleanup when {@code cleanupAfterHandout} is
+   * true.
+   *
+   * <p>Default value is 5 days + 10 hours.
+   */
+  private Duration testResourceTimeToLive = Duration.ofHours(130);
 
   public boolean isCleanupAfterHandout() {
     return cleanupAfterHandout;
@@ -108,6 +110,14 @@ public class CrlConfiguration {
     this.cleanupAfterHandout = cleanupAfterHandout;
   }
 
+  public Duration getTestResourceTimeToLive() {
+    return testResourceTimeToLive;
+  }
+
+  public void setTestResourceTimeToLive(Duration testResourceTimeToLive) {
+    this.testResourceTimeToLive = testResourceTimeToLive;
+  }
+
   /**
    * The {@link ClientConfig} in CRL's COW object. If in test, it will also include {@link
    * CleanupConfig}.
@@ -121,7 +131,7 @@ public class CrlConfiguration {
           CleanupConfig.builder()
               .setCleanupId(CLIENT_NAME + "-test")
               .setJanitorProjectId(janitorTrackResourceProjectId)
-              .setTimeToLive(TEST_RESOURCE_TIME_TO_LIVE)
+              .setTimeToLive(testResourceTimeToLive)
               .setJanitorTopicName(janitorTrackResourceTopicId)
               .setCredentials(loadJanitorClientCredential())
               .build());

--- a/src/main/java/bio/terra/buffer/service/cleanup/CleanupScheduler.java
+++ b/src/main/java/bio/terra/buffer/service/cleanup/CleanupScheduler.java
@@ -1,7 +1,6 @@
 package bio.terra.buffer.service.cleanup;
 
 import static bio.terra.buffer.app.configuration.CrlConfiguration.CLIENT_NAME;
-import static bio.terra.buffer.app.configuration.CrlConfiguration.TEST_RESOURCE_TIME_TO_LIVE;
 
 import bio.terra.buffer.app.configuration.CrlConfiguration;
 import bio.terra.buffer.common.Resource;
@@ -21,9 +20,7 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.TopicName;
 import java.io.IOException;
 import java.time.Clock;
-import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -123,8 +120,7 @@ public class CleanupScheduler {
                       objectMapper.writeValueAsString(cloudResourceUid),
                       bio.terra.janitor.model.CloudResourceUid.class))
               .creation(now)
-              .expiration(Instant.now().plus(TEST_RESOURCE_TIME_TO_LIVE).atOffset(ZoneOffset.UTC))
-              .expiration(now.plus(TEST_RESOURCE_TIME_TO_LIVE))
+              .expiration(now.plus(crlConfiguration.getTestResourceTimeToLive()))
               .putLabelsItem("client", CLIENT_NAME);
       data = ByteString.copyFromUtf8(objectMapper.writeValueAsString(body));
     } catch (IOException e) {


### PR DESCRIPTION
Background: Using a static variable as time to live make it impossible to customize this value per env. 
However, we did see a request from TDR and Leo that wants to have different values.  