### PR TITLE
[PF-1152] Delete region blocklist warning

### DIFF
--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,11 +145,10 @@ public class CreateSubnetsStep implements Step {
 
   /** Gets a map of region to IP range. */
   private Map<String, String> getRegionToIpRange() {
-    // Convert to HashMap so we can call removeAll().
-    Map<String, String> regionToIpRange = new HashMap<>(REGION_TO_IP_RANGE);
     List<String> blockedRegions = GoogleProjectConfigUtils.blockedRegions(gcpProjectConfig);
-    regionToIpRange.keySet().removeAll(blockedRegions);
-    return regionToIpRange;
+    return REGION_TO_IP_RANGE.entrySet().stream()
+            .filter(e -> !blockedRegions.contains(e.getKey()))
+            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
   }
 
   /**

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java
@@ -146,14 +146,7 @@ public class CreateSubnetsStep implements Step {
     // Convert to HashMap so we can call removeAll().
     Map<String, String> regionToIpRange = new HashMap<>(REGION_TO_IP_RANGE);
     List<String> blockedRegions = GoogleProjectConfigUtils.blockedRegions(gcpProjectConfig);
-
-    if (!REGION_TO_IP_RANGE.keySet().containsAll(blockedRegions)) {
-      logger.warn("Blocked regions contains invalid regions: {}", blockedRegions);
-    }
-
     regionToIpRange.keySet().removeAll(blockedRegions);
-    // TODO(PF-1152): Delete after fix for PF-1152 deployed everywhere.
-    logger.debug("Region to ip range: {}", regionToIpRange);
     return regionToIpRange;
   }
 


### PR DESCRIPTION
There are now regions in blocklist that aren't in `REGION_TO_IP_RANGE` (see [here](https://github.com/verily-src/terra-deployment/pull/443)) so the warning no longer makes sense.