### PR TITLE
[PF-1291] Bump test runner version

### DIFF
--- a/buffer-clienttests/build.gradle
+++ b/buffer-clienttests/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url "https://broadinstitute.jfrog.io/broadinstitute/libs-release-local/"

--- a/buffer-clienttests/build.gradle
+++ b/buffer-clienttests/build.gradle
@@ -1,9 +1,10 @@
 plugins {
     // Terra Test Runner Plugin
-    id "bio.terra.test-runner-plugin" version "0.0.7-SNAPSHOT"
+    id "bio.terra.test-runner-plugin" version "0.1.0-SNAPSHOT"
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         url "https://broadinstitute.jfrog.io/broadinstitute/libs-release-local/"
@@ -28,7 +29,7 @@ dependencies {
         googleOauth2 = "0.20.0"
 
         bufferServiceClient = "0.4.3-SNAPSHOT"
-        testRunner = "0.0.7-SNAPSHOT"
+        testRunner = "0.1.0-SNAPSHOT"
     }
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"


### PR DESCRIPTION
The latest TestRunner version was a breaking change that refactored test parameters from List<String> to Map<String,String>. 

RBS doesn't have any TestRunner changes with parameters so no migration is necessary, but upgrading now means we won't have to migrate tests anyone writes in the future.