### PR TITLE
Add batch network config settings for VPC-SC prod projects

### DIFF
--- a/src/main/resources/config/prod/resource-config/vpc_sc_v7.yml
+++ b/src/main/resources/config/prod/resource-config/vpc_sc_v7.yml
@@ -1,0 +1,35 @@
+# Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v7"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc"
+    scheme: "RANDOM_CHAR"
+  # firecloud.org/prod/for_vpc_sc_unclaimed
+  parentFolderId: "160283235721"
+  billingAccount: "0106B0-41CAA9-427C96"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "genomics.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"


### PR DESCRIPTION
**This is a potential launch blocking issue for AoU**.

The expectation has been that this has been enabled for AoU since 2021. Presumably this was an oversight and the settings should have been configured on https://github.com/DataBiosphere/terra-resource-buffer/pull/194/files#diff-0e1bb8265c93a909f273642f9cfcd825df74f4bf4c337b340ec1da6cbbec8351R29

I don't know whether this also should have been included on the other pool configs in that PR, I'm unfamiliar with those. Not high on my list right now though.

I need guidance in deploying this change.

@Qi77Qi @rtitle @gjuggler FYI