### PR TITLE
Add the vpc_sc_6 dev pool back in, still in use by Rawls

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -10,6 +10,9 @@ poolConfigs:
   - poolId: "workspace_manager_v9"
     size: 500
     resourceConfigName: "workspace_manager_v9"
+  - poolId: "vpc_sc_v6"
+    size: 300
+    resourceConfigName: "vpc_sc_v6"
   - poolId: "vpc_sc_v8"
     size: 300
     resourceConfigName: "vpc_sc_v8"


### PR DESCRIPTION
From Rawls:

```
Server Error error: ErrorReport(Rawls,{"causes":[],"exceptionClass":"bio.terra.buffer.client.ApiException","message":"{\"message\":\"Invalid pool id: vpc_sc_v6.\",\"statusCode\":400,\"causes\":[]}","source":"rawls","stackTrace":
```