### PR TITLE
Revert "Add the vpc_sc_6 pool back in, still in use by Rawls (#223)"

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -10,9 +10,6 @@ poolConfigs:
   - poolId: "workspace_manager_v9"
     size: 500
     resourceConfigName: "workspace_manager_v9"
-  - poolId: "vpc_sc_v6"
-    size: 300
-    resourceConfigName: "vpc_sc_v6"
   - poolId: "vpc_sc_v8"
     size: 300
     resourceConfigName: "vpc_sc_v8"


### PR DESCRIPTION
This reverts commit bbced2db0e5819e906c74c732301773c2e3d2b23.

See https://github.com/DataBiosphere/terra-resource-buffer/pull/223#issuecomment-1067972458