### PR TITLE
peg to a version, since master will become main and break this.

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -58,7 +58,7 @@ jobs:
         echo ::set-output name=gcr-key::$GCR_KEY
         echo ::add-mask::$GCR_KEY
     - name: Auth to GCR
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: '270.0.0'
         service_account_email: ${{ steps.vault-secret-step.outputs.gcr-email }}


### PR DESCRIPTION
Got an interesting [error](https://github.com/DataBiosphere/terra-resource-buffer/runs/5635877366?check_suite_focus=true) relating to Google's plan to switch their `master` branch to `main`.
```
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'
```

This error comes with my new all-time favorite environment variable: `SETUP_GCLOUD_I_UNDERSTAND_USING_MASTER_WILL_BREAK_MY_WORKFLOW_ON_2022_04_05`. If we don't want to make the current change, we can use that variable.