### PR TITLE
[PF-1415] reactivate de-activated pools

### DIFF
--- a/src/test/java/bio/terra/buffer/service/pool/PoolServiceTest.java
+++ b/src/test/java/bio/terra/buffer/service/pool/PoolServiceTest.java
@@ -143,30 +143,6 @@ public class PoolServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void updateFromConfig_deactivatedPoolExistsWithDuplicatePoolId_throwException()
-      throws Exception {
-    PoolId poolId = PoolId.create("poolId");
-    PoolWithResourceConfig parsedPoolConfig =
-        PoolWithResourceConfig.create(
-            new PoolConfig()
-                .poolId(poolId.toString())
-                .size(10)
-                .resourceConfigName(RESOURCE_CONFIG_NAME),
-            newResourceConfig());
-
-    poolService.updateFromConfig(ImmutableList.of(parsedPoolConfig));
-    bufferDao.deactivatePools(ImmutableList.of(poolId));
-    List<Pool> pools = bufferDao.retrievePools();
-
-    Pool createdPool = pools.get(0);
-    assertEquals(PoolStatus.DEACTIVATED, createdPool.status());
-
-    assertThrows(
-        RuntimeException.class,
-        () -> poolService.updateFromConfig(ImmutableList.of(parsedPoolConfig)));
-  }
-
-  @Test
   public void updateFromConfig_deactivatePool_updatePoolStatusSuccess() throws Exception {
     PoolId poolId = PoolId.create("poolId");
     PoolWithResourceConfig parsedPoolConfig =

--- a/src/test/java/bio/terra/buffer/service/pool/PoolServiceTest.java
+++ b/src/test/java/bio/terra/buffer/service/pool/PoolServiceTest.java
@@ -200,7 +200,7 @@ public class PoolServiceTest extends BaseUnitTest {
 
   @Test
   public void updateFromConfig_createDeactivateReactivate_success() throws Exception {
-    // create two pools
+    // Create two pools so we fully exercise the batch methods in the DAO.
     PoolId poolId1 = PoolId.create("poolId1");
     PoolWithResourceConfig parsedPoolConfig1 =
         PoolWithResourceConfig.create(


### PR DESCRIPTION
As described in [this document](https://docs.google.com/document/d/1aXOF_0T_Qje4O5KbcKqgNPGhnytm97dPSBaGnzNtEUY/edit?usp=sharing&resourcekey=0-Vwd3zNcBNJ7mbbGq0OuflA), implementing pool re-activation after deactivation. Simply add the pool back into the schema file and it should clear the expiration and set the status back to ACTIVE. The scheduler should add flights to return the pool to its stated size.