### PR TITLE
Drop some unused AoU pools

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -10,12 +10,6 @@ poolConfigs:
   - poolId: "workspace_manager_v9"
     size: 500
     resourceConfigName: "workspace_manager_v9"
-  - poolId: "vpc_sc_v6"
-    size: 50
-    resourceConfigName: "vpc_sc_v6"
-  - poolId: "vpc_sc_v8"
-    size: 300
-    resourceConfigName: "vpc_sc_v8"
   - poolId: "vpc_sc_v9"
     size: 300
     resourceConfigName: "vpc_sc_v9"

--- a/src/main/resources/config/perf/pool_schema.yml
+++ b/src/main/resources/config/perf/pool_schema.yml
@@ -13,9 +13,6 @@ poolConfigs:
   - poolId: "cwb_ws_perf_v6"
     size: 500
     resourceConfigName: "cwb_ws_perf_v6"
-  - poolId: "vpc_sc_v5"
-    size: 500
-    resourceConfigName: "vpc_sc_v5"
   - poolId: "vpc_sc_v6"
     size: 500
     resourceConfigName: "vpc_sc_v6"

--- a/src/main/resources/config/prod/pool_schema.yml
+++ b/src/main/resources/config/prod/pool_schema.yml
@@ -13,9 +13,6 @@ poolConfigs:
   - poolId: "cwb_ws_prod_v6"
     size: 3000
     resourceConfigName: "cwb_ws_prod_v6"
-  - poolId: "vpc_sc_v5"
-    size: 1000
-    resourceConfigName: "vpc_sc_v5"
   - poolId: "vpc_sc_v6"
     size: 1000
     resourceConfigName: "vpc_sc_v6"


### PR DESCRIPTION
I left an extra 2 versions in prod to allow for potential rollback. I also noted some versions in alpha+staging, which are definitely unused by AoU. I'm not comfortable touching these without knowing their purpose, can check with @yonghaoy when he's back. By my estimate they could simply be deleted.

I'm also noticing that all historical pool config yaml files appear to be preserved, so I haven't touched those.