### PR TITLE
[PF-1557] Update master_push.yml

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -49,6 +49,7 @@ jobs:
       uses: actions/checkout@master
       with:
         ref: ${{ steps.controls.outputs.checkout-branch }}
+        token: ${{ secrets.BROADBOT_TOKEN }}
     - name: Skip version bump merges
       id: skiptest
       uses: ./.github/actions/bump-skip

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -60,7 +60,7 @@ jobs:
       id: tag
       env:
         DEFAULT_BUMP: patch
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         HOTFIX_BRANCHES: hotfix.*
         OVERRIDE_BUMP: ${{ steps.controls.outputs.semver-part }}
         RELEASE_BRANCHES: master


### PR DESCRIPTION
This action updates the version number in `settings.gradle`. In order to merge this change to the main branch without reviews, this must be done as an admin (in this case Broadbot). I've already set up the BROADBOT_TOKEN secret via the Vault -> GHA secrets terraform.