### PR TITLE
[PF-2049] terra-resource-buffer: Remove paths ignore from Github workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
     branches: [ master ]
     paths-ignore: [ '**.md' ]
   pull_request:
+    # Branch settings require status checks before merging, so don't add paths-ignore.
     branches: [ '**' ]
-    paths-ignore: [ '**.md' ]
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
 jobs:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,8 +1,8 @@
 name: dsp-appsec-trivy
 on:
   pull_request:
+    # Branch settings require status checks before merging, so don't add paths-ignore.
     branches: [ '**' ]
-    paths-ignore: [ '**.md' ]
 
 jobs:
   appsec-trivy:


### PR DESCRIPTION
Follow-up on similar changes in Terra-cli - https://github.com/DataBiosphere/terra-cli/pull/327

---
Issue - If changeset only has .md files (readme.md for example) the PR check (github workflow) does not report the status as success skipped, thus leading to a PR that can't be merged

As a workaround remove this config for now
Further work will be carried out in https://broadworkbench.atlassian.net/browse/PF-2048