### PR TITLE
[PF-2511] Fix workflow to notify Broad devops

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -25,6 +25,9 @@ env:
 jobs:
   tag-build-push:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      is-bump: ${{ steps.skiptest.outputs.is-bump }}
     steps:
       - name: Set part of semantic version to bump
         id: controls
@@ -86,12 +89,28 @@ jobs:
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
-      - name: Update Version Mapping
-        if: steps.skiptest.outputs.is-bump == 'no'
-        uses: broadinstitute/repository-dispatch@master
-        with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          repository: broadinstitute/terra-helmfile
-          event-type: update-service
-          client-payload: '{"service": "buffer", "version": "${{ steps.tag.outputs.tag }}"}'
+  report-to-sherlock:
+    # Report new WSM version to Broad DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: tag-publish-job
+    if: ${{ needs.tag-publish-job.outputs.is-bump == 'no' }}
+    with:
+      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      chart-name: 'buffer'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
+  set-version-in-dev:
+    # Put new RBS version in Broad dev environment
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [tag-publish-job, report-to-sherlock]
+    if: ${{ needs.tag-publish-job.outputs.is-bump == 'no' }}
+    with:
+      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      chart-name: 'buffer'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -90,7 +90,7 @@ jobs:
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
   report-to-sherlock:
-    # Report new WSM version to Broad DevOps
+    # Report new RBS version to Broad DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: tag-publish-job
     if: ${{ needs.tag-publish-job.outputs.is-bump == 'no' }}

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -92,10 +92,10 @@ jobs:
   report-to-sherlock:
     # Report new RBS version to Broad DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: tag-publish-job
-    if: ${{ needs.tag-publish-job.outputs.is-bump == 'no' }}
+    needs: tag-build-push
+    if: ${{ needs.tag-build-push.outputs.is-bump == 'no' }}
     with:
-      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      new-version: ${{ needs.tag-build-push.outputs.tag }}
       chart-name: 'buffer'
     permissions:
       contents: 'read'
@@ -104,10 +104,10 @@ jobs:
   set-version-in-dev:
     # Put new RBS version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs: [tag-publish-job, report-to-sherlock]
-    if: ${{ needs.tag-publish-job.outputs.is-bump == 'no' }}
+    needs: [tag-build-push, report-to-sherlock]
+    if: ${{ needs.tag-build-push.outputs.is-bump == 'no' }}
     with:
-      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      new-version: ${{ needs.tag-build-push.outputs.tag }}
       chart-name: 'buffer'
       environment-name: 'dev'
     secrets:


### PR DESCRIPTION
The existing `repository-dispatch` based notification flow is broken, and publishing workflows have been broken for several weeks (though no real PRs were added in that time).