### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/actions/bump-skip/action.yml
+++ b/.github/actions/bump-skip/action.yml
@@ -24,5 +24,5 @@ runs:
           IS_BUMP=yes
         fi
         echo "IS_BUMP=$IS_BUMP"
-        echo ::set-output name=is-bump::$IS_BUMP
+        echo is-bump=$IS_BUMP >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -43,7 +43,7 @@ jobs:
           echo ::set-output name=semver-part::$SEMVER_PART
           echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
       - name: Checkout current code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
           token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -40,8 +40,8 @@ jobs:
             SEMVER_PART=${{ github.event.inputs.bump }}
             CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
           fi
-          echo ::set-output name=semver-part::$SEMVER_PART
-          echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
+          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
+          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
       - name: Checkout current code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-runner-nightly-perf.yml
+++ b/.github/workflows/test-runner-nightly-perf.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/test-runner-nightly-perf.yml
+++ b/.github/workflows/test-runner-nightly-perf.yml
@@ -34,7 +34,7 @@ jobs:
           buffer-clienttests/tools/render-config.sh buffertest ${{ steps.vault-token-step.outputs.vault-token }}
           buffer-clienttests/tools/render-config.sh yyu ${{ steps.vault-token-step.outputs.vault-token }}
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/caches

--- a/.github/workflows/test-runner-nightly-perf.yml
+++ b/.github/workflows/test-runner-nightly-perf.yml
@@ -28,7 +28,7 @@ jobs:
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
           echo ::add-mask::$VAULT_TOKEN
-          echo ::set-output name=vault-token::$VAULT_TOKEN
+          echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
       - name: Render configs for Test Runner
         run: |
           buffer-clienttests/tools/render-config.sh buffertest ${{ steps.vault-token-step.outputs.vault-token }}

--- a/.github/workflows/test-runner-nightly-perf.yml
+++ b/.github/workflows/test-runner-nightly-perf.yml
@@ -48,7 +48,7 @@ jobs:
           TEST_RUNNER_SERVER_SPECIFICATION_FILE="buffertest.json" ./gradlew  runTest --scan --args="configs/HandoutResourcesThenWaitForRefill.json build/reports"
       - name: Upload Test Reports
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: Test Reports
           path: buffer-clienttests/build/reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,8 @@ jobs:
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
           echo ::add-mask::$VAULT_TOKEN
-          echo ::set-output name=vault-token::$VAULT_TOKEN
+          echo status=$pass >> $GITHUB_OUTPUT
+          echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
       - name: Grant execute permission for render-config
         if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x local-dev/render-config.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Skip version bump merges
         id: skiptest
         uses: ./.github/actions/bump-skip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
           echo ::add-mask::$VAULT_TOKEN
-          echo status=$pass >> $GITHUB_OUTPUT
           echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
       - name: Grant execute permission for render-config
         if: steps.skiptest.outputs.is-bump == 'no'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           java-version: 17
       - name: Cache Gradle packages
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,13 +97,13 @@ jobs:
         run: ./gradlew integrationTest --scan
       - name: Upload Test Reports
         if: always() && steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: Test Reports
           path: build/reports
       - name: Upload Jacoco Reports
         if: always() && steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Test Reports
           path: build/jacoco

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '17'
 
       # set up Gradle cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -37,7 +37,7 @@ jobs:
             | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log
           # export image name from the log
           image=$(grep 'Built image' build.log | awk '{print $NF}')
-          echo "::set-output name=image::${image}"
+          echo image=${image} >> $GITHUB_OUTPUT          
       # scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -37,7 +37,7 @@ jobs:
             | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log
           # export image name from the log
           image=$(grep 'Built image' build.log | awk '{print $NF}')
-          echo image="${image}" >> $GITHUB_OUTPUT          
+          echo image="${image}" >> $GITHUB_OUTPUT
       # scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,7 +10,7 @@ jobs:
     name: DSP AppSec Trivy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # fetch JDK
       - uses: actions/setup-java@v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -37,7 +37,7 @@ jobs:
             | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log
           # export image name from the log
           image=$(grep 'Built image' build.log | awk '{print $NF}')
-          echo image=${image} >> $GITHUB_OUTPUT          
+          echo image="${image}" >> $GITHUB_OUTPUT          
       # scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- use actions/cache@v3 instead of v2
- use actions/upload-artifact@v3 instead of v2
- use setup-node@v3 instead of v2
- replace 'set-output' command