### PR TITLE
[PF-2639] Add new pool for WSM with BigQuery Transfer API enabled

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -16,3 +16,6 @@ poolConfigs:
   - poolId: "workspace_manager_v9"
     size: 500
     resourceConfigName: "workspace_manager_v9"
+  - poolId: "workspace_manager_v10"
+    size: 300
+    resourceConfigName: "workspace_manager_v10"

--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -17,5 +17,5 @@ poolConfigs:
     size: 500
     resourceConfigName: "workspace_manager_v9"
   - poolId: "workspace_manager_v10"
-    size: 300
+    size: 500
     resourceConfigName: "workspace_manager_v10"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v10.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v10.yml
@@ -1,0 +1,31 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v10"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-d"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "bigquerydatatransfer.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "genomics.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "notebooks.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -20,5 +20,5 @@ poolConfigs:
     size: 500
     resourceConfigName: "workspace_manager_v9"
   - poolId: "workspace_manager_v10"
-    size: 300
+    size: 500
     resourceConfigName: "workspace_manager_v10"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -19,3 +19,6 @@ poolConfigs:
   - poolId: "workspace_manager_v9"
     size: 500
     resourceConfigName: "workspace_manager_v9"
+  - poolId: "workspace_manager_v10"
+    size: 300
+    resourceConfigName: "workspace_manager_v10"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v10.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v10.yml
@@ -1,0 +1,31 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v10"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-t"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "375605435272" #test.firecloud.org/tools/buffer-tools/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "bigquerydatatransfer.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "genomics.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "notebooks.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"


### PR DESCRIPTION
Adds a new WSM pool with `bigquerydatatransfer.googleapis.com` enabled and no other changes over v9 for `tools` and `dev` environments, which are the only Broad environments which use WSM-managed GCP projects.

I'll remove the v9 pool in a few days after configuring all instances to use the v10 pool instead.