### PR TITLE
[PF-2639] Remove v9 configuration

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -13,9 +13,6 @@ poolConfigs:
   - poolId: "vpc_sc_v10"
     size: 300
     resourceConfigName: "vpc_sc_v10"
-  - poolId: "workspace_manager_v9"
-    size: 500
-    resourceConfigName: "workspace_manager_v9"
   - poolId: "workspace_manager_v10"
     size: 500
     resourceConfigName: "workspace_manager_v10"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -16,9 +16,6 @@ poolConfigs:
   - poolId: "vpc_sc_qa-fiab_v4"
     size: 100
     resourceConfigName: "vpc_sc_qa-fiab_v4"
-  - poolId: "workspace_manager_v9"
-    size: 500
-    resourceConfigName: "workspace_manager_v9"
   - poolId: "workspace_manager_v10"
     size: 500
     resourceConfigName: "workspace_manager_v10"


### PR DESCRIPTION
Followup to #265, all WSM instances are now using the v10 pool and I've confirmed the `tools` and `dev` v9 pools have had 0 handout requests for several days.