### PR TITLE
[PF-2844] Add explicit validation for RANDOM_CHAR pattern

### DIFF
--- a/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
@@ -1,10 +1,13 @@
 package bio.terra.buffer.service.pool;
 
+import static bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator.MAX_LENGTH_GCP_PROJECT_ID;
 import static bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator.MAX_LENGTH_GCP_PROJECT_ID_PREFIX;
+import static bio.terra.buffer.service.resource.projectid.GcpProjectIdGenerator.RANDOM_ID_SIZE;
 
 import bio.terra.buffer.common.exception.InvalidPoolConfigException;
 import bio.terra.buffer.generated.model.GcpProjectConfig;
 import bio.terra.buffer.generated.model.ProjectIdSchema;
+import bio.terra.buffer.generated.model.ProjectIdSchema.SchemeEnum;
 import bio.terra.buffer.generated.model.ResourceConfig;
 
 /**
@@ -33,6 +36,13 @@ public class GcpResourceConfigValidator implements ResourceConfigValidator {
       throw new InvalidPoolConfigException(
           String.format(
               "Project id prefix is too long for TWO_WORDS_NUMBER naming scheme: %s",
+              config.getConfigName()));
+    } else if (gcpProjectConfig.getProjectIdSchema().getScheme().equals(SchemeEnum.RANDOM_CHAR)
+        && gcpProjectConfig.getProjectIdSchema().getPrefix().length() + RANDOM_ID_SIZE
+            > MAX_LENGTH_GCP_PROJECT_ID) {
+      throw new InvalidPoolConfigException(
+          String.format(
+              "Project id prefix is too long for RANDOM_CHAR naming scheme: %s",
               config.getConfigName()));
     }
   }

--- a/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/buffer/service/pool/GcpResourceConfigValidator.java
@@ -27,19 +27,18 @@ public class GcpResourceConfigValidator implements ResourceConfigValidator {
       throw new InvalidPoolConfigException(
           String.format("Missing billing account for config: %s", config.getConfigName()));
     }
-    if (gcpProjectConfig
-            .getProjectIdSchema()
-            .getScheme()
-            .equals(ProjectIdSchema.SchemeEnum.TWO_WORDS_NUMBER)
-        && gcpProjectConfig.getProjectIdSchema().getPrefix().length()
-            > MAX_LENGTH_GCP_PROJECT_ID_PREFIX) {
+    if (gcpProjectConfig.getProjectIdSchema().getScheme()
+            == ProjectIdSchema.SchemeEnum.TWO_WORDS_NUMBER
+        && (gcpProjectConfig.getProjectIdSchema().getPrefix().length()
+            > MAX_LENGTH_GCP_PROJECT_ID_PREFIX)) {
       throw new InvalidPoolConfigException(
           String.format(
               "Project id prefix is too long for TWO_WORDS_NUMBER naming scheme: %s",
               config.getConfigName()));
-    } else if (gcpProjectConfig.getProjectIdSchema().getScheme().equals(SchemeEnum.RANDOM_CHAR)
-        && gcpProjectConfig.getProjectIdSchema().getPrefix().length() + RANDOM_ID_SIZE
-            > MAX_LENGTH_GCP_PROJECT_ID) {
+    }
+    if (gcpProjectConfig.getProjectIdSchema().getScheme() == SchemeEnum.RANDOM_CHAR
+        && (gcpProjectConfig.getProjectIdSchema().getPrefix().length() + RANDOM_ID_SIZE
+            > MAX_LENGTH_GCP_PROJECT_ID)) {
       throw new InvalidPoolConfigException(
           String.format(
               "Project id prefix is too long for RANDOM_CHAR naming scheme: %s",

--- a/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
+++ b/src/main/java/bio/terra/buffer/service/resource/projectid/GcpProjectIdGenerator.java
@@ -17,13 +17,13 @@ public class GcpProjectIdGenerator {
    * The size of project when generating random characters. Choose size as 8 based on AoU's
    * historical experience, increase if 8 is not enough for a pool's naming.
    */
-  @VisibleForTesting static final int RANDOM_ID_SIZE = 8;
+  public static final int RANDOM_ID_SIZE = 8;
 
   /** The largest number to use for random suffixes for adjective/noun project IDs. */
   @VisibleForTesting static final int RANDOM_SUFFIX_LIMIT = 10000;
 
   /** The maximum allowed length for a GCP project id. */
-  private static final int MAX_LENGTH_GCP_PROJECT_ID = 30;
+  public static final int MAX_LENGTH_GCP_PROJECT_ID = 30;
 
   /**
    * The maximum allowed length for a GCP project id prefix (e.g. "terra-") when using the

--- a/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
+++ b/src/test/java/bio/terra/buffer/service/pool/ResourceConfigValidatorTest.java
@@ -6,6 +6,7 @@ import bio.terra.buffer.common.BaseUnitTest;
 import bio.terra.buffer.common.exception.InvalidPoolConfigException;
 import bio.terra.buffer.generated.model.GcpProjectConfig;
 import bio.terra.buffer.generated.model.ProjectIdSchema;
+import bio.terra.buffer.generated.model.ProjectIdSchema.SchemeEnum;
 import bio.terra.buffer.generated.model.ResourceConfig;
 import org.junit.jupiter.api.Test;
 
@@ -13,8 +14,7 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
   private static GcpProjectConfig newValidGcpProjectConfig() {
     return new GcpProjectConfig()
         .billingAccount("123")
-        .projectIdSchema(
-            new ProjectIdSchema().prefix("prefix").scheme(ProjectIdSchema.SchemeEnum.RANDOM_CHAR));
+        .projectIdSchema(new ProjectIdSchema().prefix("prefix").scheme(SchemeEnum.RANDOM_CHAR));
   }
 
   @Test
@@ -38,7 +38,7 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
   }
 
   @Test
-  public void testValidateGcpConfig_prefixTooLong() {
+  public void testValidateGcpConfig_twoWordPrefixTooLong() {
     ResourceConfig resourceConfig =
         new ResourceConfig()
             .configName("testConfig")
@@ -47,7 +47,7 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
                     .projectIdSchema(
                         new ProjectIdSchema()
                             .prefix("prefixlongerthan12characters")
-                            .scheme(ProjectIdSchema.SchemeEnum.TWO_WORDS_NUMBER)));
+                            .scheme(SchemeEnum.TWO_WORDS_NUMBER)));
     InvalidPoolConfigException exception =
         assertThrows(
             InvalidPoolConfigException.class,
@@ -56,5 +56,26 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
         exception
             .getMessage()
             .contains("Project id prefix is too long for TWO_WORDS_NUMBER naming scheme"));
+  }
+
+  @Test
+  public void testValidateGcpConfig_randomCharPrefixTooLong() {
+    ResourceConfig resourceConfig =
+        new ResourceConfig()
+            .configName("testConfig")
+            .gcpProjectConfig(
+                newValidGcpProjectConfig()
+                    .projectIdSchema(
+                        new ProjectIdSchema()
+                            .prefix("prefixlongerthan22characters")
+                            .scheme(SchemeEnum.RANDOM_CHAR)));
+    InvalidPoolConfigException exception =
+        assertThrows(
+            InvalidPoolConfigException.class,
+            () -> new GcpResourceConfigValidator().validate(resourceConfig));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Project id prefix is too long for RANDOM_CHAR naming scheme"));
   }
 }


### PR DESCRIPTION
Currently, RBS only validates prefix length for pool names using the `TWO_WORDS_NUMBER` scheme. However, it will also fail to produce valid names with the `RANDOM_CHAR` scheme if the prefix is too long (currently >22 characters). This adds explicit validation so that pool configuration fails earlier instead of each flight failing individually.