### PR TITLE
[PF-2872] Stop enabling genomic api

### DIFF
--- a/src/main/resources/config/alpha/pool_schema.yml
+++ b/src/main/resources/config/alpha/pool_schema.yml
@@ -1,12 +1,15 @@
 # Resource Buffer Service Pools Schema in alpha environment
 ---
 poolConfigs:
-  - poolId: "cwb_ws_alpha_v6"
+  - poolId: "cwb_ws_alpha_v7"
     size: 100
-    resourceConfigName: "cwb_ws_resource_alpha_v6"
+    resourceConfigName: "cwb_ws_resource_alpha_v7"
   - poolId: "datarepo_v1"
     size: 300
     resourceConfigName: "datarepo_v1"
   - poolId: "vpc_sc_v5"
     size: 100
     resourceConfigName: "vpc_sc_v5"
+  - poolId: "vpc_sc_v6"
+    size: 100
+    resourceConfigName: "vpc_sc_v6"

--- a/src/main/resources/config/alpha/pool_schema.yml
+++ b/src/main/resources/config/alpha/pool_schema.yml
@@ -7,9 +7,6 @@ poolConfigs:
   - poolId: "datarepo_v1"
     size: 300
     resourceConfigName: "datarepo_v1"
-  - poolId: "vpc_sc_v5"
-    size: 100
-    resourceConfigName: "vpc_sc_v5"
   - poolId: "vpc_sc_v6"
     size: 100
     resourceConfigName: "vpc_sc_v6"

--- a/src/main/resources/config/alpha/resource-config/cwb_ws_resource_alpha_v7.yml
+++ b/src/main/resources/config/alpha/resource-config/cwb_ws_resource_alpha_v7.yml
@@ -1,0 +1,32 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_resource_alpha_v6"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-alpha"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/alpha/CommunityWorkbench
+  parentFolderId: "102618195587"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/alpha/resource-config/cwb_ws_resource_alpha_v7.yml
+++ b/src/main/resources/config/alpha/resource-config/cwb_ws_resource_alpha_v7.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "cwb_ws_resource_alpha_v6"
+configName: "cwb_ws_resource_alpha_v7"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-alpha"

--- a/src/main/resources/config/alpha/resource-config/vpc_sc_v6.yml
+++ b/src/main/resources/config/alpha/resource-config/vpc_sc_v6.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "vpc_sc_v5"
+configName: "vpc_sc_v6"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-vpc-sc-alpha"

--- a/src/main/resources/config/alpha/resource-config/vpc_sc_v6.yml
+++ b/src/main/resources/config/alpha/resource-config/vpc_sc_v6.yml
@@ -1,0 +1,34 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_v5"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-alpha"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/alpha/for_vpc_sc_unclaimed
+  parentFolderId: "38455243798"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/buffertest/pool_schema.yml
+++ b/src/main/resources/config/buffertest/pool_schema.yml
@@ -1,6 +1,6 @@
 # RBS Pools Schema for running buffer service integration test and performace test.
 ---
 poolConfigs:
-  - poolId: "resource_buffer_test_v1"
+  - poolId: "resource_buffer_test_v2"
     size: 1500
-    resourceConfigName: "resource_buffer_test_v1"
+    resourceConfigName: "resource_buffer_test_v2"

--- a/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v2.yml
+++ b/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v2.yml
@@ -20,6 +20,7 @@ gcpProjectConfig:
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
     - "dns.googleapis.com"
+    - "genomics.googleapis.com"
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"

--- a/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v2.yml
+++ b/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v2.yml
@@ -20,7 +20,6 @@ gcpProjectConfig:
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
     - "dns.googleapis.com"
-    - "genomics.googleapis.com"
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"

--- a/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v2.yml
+++ b/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v2.yml
@@ -1,6 +1,6 @@
 # Resource template for running buffer service performance test
 ---
-configName: "resource_buffer_test_v1"
+configName: "resource_buffer_test_v2"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "buffer-test"

--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -1,18 +1,18 @@
 # Resource Buffer Service Pools Schema in dev environment
 ---
 poolConfigs:
-  - poolId: "cwb_ws_dev_v6"
+  - poolId: "cwb_ws_dev_v7"
     size: 300
-    resourceConfigName: "cwb_ws_resource_dev_v6"
+    resourceConfigName: "cwb_ws_resource_dev_v7"
   - poolId: "datarepo_fakeprod_v1"
     size: 50
     resourceConfigName: "datarepo_fakeprod_v1"
   - poolId: "datarepo_v3"
     size: 300
     resourceConfigName: "datarepo_v3"
-  - poolId: "vpc_sc_v10"
+  - poolId: "vpc_sc_v11"
     size: 300
-    resourceConfigName: "vpc_sc_v10"
-  - poolId: "workspace_manager_v10"
+    resourceConfigName: "vpc_sc_v11"
+  - poolId: "workspace_manager_v11"
     size: 500
-    resourceConfigName: "workspace_manager_v10"
+    resourceConfigName: "workspace_manager_v11"

--- a/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v7.yml
+++ b/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v7.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "cwb_ws_resource_dev_v6"
+configName: "cwb_ws_resource_dev_v7"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-dev"

--- a/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v7.yml
+++ b/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v7.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# Community Workbench buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "cwb_ws_resource_dev_v6"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-dev"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # test.firecloud.org/dev/CommunityWorkbench
+  parentFolderId: "803412578462"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -25,10 +25,8 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
-    enableNetworkMonitoring: "true"
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/dev/resource-config/vpc_sc_v11.yml
+++ b/src/main/resources/config/dev/resource-config/vpc_sc_v11.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# # Projects with VPC-SC configuration
 ---
-configName: "resource_buffer_test_v1"
+configName: "vpc_sc_v10"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-vpc-sc-dev"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # test.firecloud.org/dev/for_vpc_sc_unclaimed
+  parentFolderId: "1061905712535"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -23,12 +23,18 @@ gcpProjectConfig:
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
+    - "serviceusage.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  serviceUsage:
+    bigQuery:
+      overrideBigQueryDailyUsageQuota: true
+      bigQueryDailyUsageQuotaOverrideValueMebibytes: 38146972 # 40 TB
+  securityGroup: "high"

--- a/src/main/resources/config/dev/resource-config/vpc_sc_v11.yml
+++ b/src/main/resources/config/dev/resource-config/vpc_sc_v11.yml
@@ -1,6 +1,6 @@
 # # Projects with VPC-SC configuration
 ---
-configName: "vpc_sc_v10"
+configName: "vpc_sc_v11"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-vpc-sc-dev"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v11.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v11.yml
@@ -1,6 +1,6 @@
 # Workspace Manager buffered workspace template
 ---
-configName: "workspace_manager_v10"
+configName: "workspace_manager_v11"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-wsm-d"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v11.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v11.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v10"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-d"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "bigquerydatatransfer.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "notebooks.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/perf/pool_schema.yml
+++ b/src/main/resources/config/perf/pool_schema.yml
@@ -1,18 +1,15 @@
 # RBS Pools Schema for running buffer service performance test.
 ---
 poolConfigs:
-  - poolId: "cwb_ws_perf_v6"
+  - poolId: "cwb_ws_perf_v7"
     size: 500
-    resourceConfigName: "cwb_ws_perf_v6"
+    resourceConfigName: "cwb_ws_perf_v7"
   - poolId: "datarepo_v1"
     size: 300
     resourceConfigName: "datarepo_v1"
-  - poolId: "vpc_sc_v7"
+  - poolId: "vpc_sc_v9"
     size: 500
-    resourceConfigName: "vpc_sc_v7"
-  - poolId: "vpc_sc_v8"
-    size: 500
-    resourceConfigName: "vpc_sc_v8"
-  - poolId: "workspace_manager_v5"
+    resourceConfigName: "vpc_sc_v9"
+  - poolId: "workspace_manager_v6"
     size: 20
-    resourceConfigName: "workspace_manager_v5"
+    resourceConfigName: "workspace_manager_v6"

--- a/src/main/resources/config/perf/resource-config/cwb_ws_perf_v7.yml
+++ b/src/main/resources/config/perf/resource-config/cwb_ws_perf_v7.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "cwb_ws_perf_v6"
+configName: "cwb_ws_perf_v7"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-perf"

--- a/src/main/resources/config/perf/resource-config/cwb_ws_perf_v7.yml
+++ b/src/main/resources/config/perf/resource-config/cwb_ws_perf_v7.yml
@@ -1,22 +1,22 @@
-# Resource template for running buffer service performance test
+# Community Workbench buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "cwb_ws_perf_v6"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-perf"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # test.firecloud.org/perf/CommunityWorkbench
+  parentFolderId: "246142551922"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
     - "compute.googleapis.com"
     - "container.googleapis.com"
+    - "containerregistry.googleapis.com"
     - "cloudbilling.googleapis.com"
     - "clouderrorreporting.googleapis.com"
     - "cloudkms.googleapis.com"
     - "cloudtrace.googleapis.com"
-    - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
     - "dns.googleapis.com"
@@ -25,10 +25,8 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
-    enableNetworkMonitoring: "true"
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/perf/resource-config/resource_perf_v3.yml
+++ b/src/main/resources/config/perf/resource-config/resource_perf_v3.yml
@@ -1,6 +1,6 @@
 # Resource template for running buffer service performance test
 ---
-configName: "resource_perf_v2"
+configName: "resource_perf_v3"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-perf"

--- a/src/main/resources/config/perf/resource-config/resource_perf_v3.yml
+++ b/src/main/resources/config/perf/resource-config/resource_perf_v3.yml
@@ -1,12 +1,12 @@
 # Resource template for running buffer service performance test
 ---
-configName: "resource_buffer_test_v1"
+configName: "resource_perf_v2"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-perf"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # RBS Testing
+  parentFolderId: "637867149294"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -26,9 +26,9 @@ gcpProjectConfig:
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
   iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
+    - members: ["group:terra-rbs-test@broadinstitute.org"]
       role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
+    - members: ["group:terra-rbs-viewer-test@broadinstitute.org"]
       role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"

--- a/src/main/resources/config/perf/resource-config/vpc_sc_v9.yml
+++ b/src/main/resources/config/perf/resource-config/vpc_sc_v9.yml
@@ -1,6 +1,6 @@
 # Projects with VPC-SC configuration
 ---
-configName: "vpc_sc_v8"
+configName: "vpc_sc_v9"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-vpc-sc-perf"

--- a/src/main/resources/config/perf/resource-config/vpc_sc_v9.yml
+++ b/src/main/resources/config/perf/resource-config/vpc_sc_v9.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# Projects with VPC-SC configuration
 ---
-configName: "resource_buffer_test_v1"
+configName: "vpc_sc_v8"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-vpc-sc-perf"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # test.firecloud.org/perf/for_vpc_sc_unclaimed
+  parentFolderId: "533417334224"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -23,12 +23,18 @@ gcpProjectConfig:
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
+    - "serviceusage.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  serviceUsage:
+    bigQuery:
+      overrideBigQueryDailyUsageQuota: true
+      bigQueryDailyUsageQuotaOverrideValueMebibytes: 38146972 # 40 TB
+  securityGroup: "high"

--- a/src/main/resources/config/perf/resource-config/workspace_manager_v6.yml
+++ b/src/main/resources/config/perf/resource-config/workspace_manager_v6.yml
@@ -1,6 +1,6 @@
 # Workspace Manager buffered workspace template
 ---
-configName: "workspace_manager_v5"
+configName: "workspace_manager_v6"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-wsm-dev"

--- a/src/main/resources/config/perf/resource-config/workspace_manager_v6.yml
+++ b/src/main/resources/config/perf/resource-config/workspace_manager_v6.yml
@@ -1,12 +1,11 @@
-# Resource template for running buffer service performance test
+# Workspace Manager buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "workspace_manager_v5"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-wsm-dev"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  parentFolderId: "199572063713"  #test.firecloud.org/perf/buffer-perf/workspace_manager
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -23,12 +22,8 @@ gcpProjectConfig:
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"

--- a/src/main/resources/config/prod/pool_schema.yml
+++ b/src/main/resources/config/prod/pool_schema.yml
@@ -1,15 +1,12 @@
 # Resource Buffer Service Pools Schema in prod environment
 ---
 poolConfigs:
-  - poolId: "cwb_ws_prod_v6"
+  - poolId: "cwb_ws_prod_v7"
     size: 3000
-    resourceConfigName: "cwb_ws_prod_v6"
+    resourceConfigName: "cwb_ws_prod_v7"
   - poolId: "datarepo_v1"
     size: 1000
     resourceConfigName: "datarepo_v1"
-  - poolId: "vpc_sc_v8"
+  - poolId: "vpc_sc_v10"
     size: 1000
-    resourceConfigName: "vpc_sc_v8"
-  - poolId: "vpc_sc_v9"
-    size: 1000
-    resourceConfigName: "vpc_sc_v9"
+    resourceConfigName: "vpc_sc_v10"

--- a/src/main/resources/config/prod/resource-config/cwb_ws_prod_v7.yml
+++ b/src/main/resources/config/prod/resource-config/cwb_ws_prod_v7.yml
@@ -1,22 +1,22 @@
-# Resource template for running buffer service performance test
+# Community Workbench buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "cwb_ws_prod_v6"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
-  billingAccount: "01A82E-CA8A14-367457"
+  # firecloud.org/prod/CommunityWorkbench
+  parentFolderId: "710468670182"
+  billingAccount: "0106B0-41CAA9-427C96"
   enabledApis:
     - "bigquery-json.googleapis.com"
     - "compute.googleapis.com"
     - "container.googleapis.com"
+    - "containerregistry.googleapis.com"
     - "cloudbilling.googleapis.com"
     - "clouderrorreporting.googleapis.com"
     - "cloudkms.googleapis.com"
     - "cloudtrace.googleapis.com"
-    - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
     - "dns.googleapis.com"
@@ -25,10 +25,8 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
-    enableNetworkMonitoring: "true"
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/prod/resource-config/cwb_ws_prod_v7.yml
+++ b/src/main/resources/config/prod/resource-config/cwb_ws_prod_v7.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "cwb_ws_prod_v6"
+configName: "cwb_ws_prod_v7"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra"

--- a/src/main/resources/config/prod/resource-config/vpc_sc_v10.yml
+++ b/src/main/resources/config/prod/resource-config/vpc_sc_v10.yml
@@ -1,6 +1,6 @@
 # Projects with VPC-SC configuration
 ---
-configName: "vpc_sc_v9"
+configName: "vpc_sc_v10"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-vpc-sc"

--- a/src/main/resources/config/prod/resource-config/vpc_sc_v10.yml
+++ b/src/main/resources/config/prod/resource-config/vpc_sc_v10.yml
@@ -1,13 +1,13 @@
-# Resource template for running buffer service performance test
+# Projects with VPC-SC configuration
 ---
-configName: "resource_buffer_test_v1"
+configName: "vpc_sc_v9"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-vpc-sc"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
-  billingAccount: "01A82E-CA8A14-367457"
+  # firecloud.org/prod/for_vpc_sc_unclaimed
+  parentFolderId: "160283235721"
+  billingAccount: "0106B0-41CAA9-427C96"
   enabledApis:
     - "bigquery-json.googleapis.com"
     - "compute.googleapis.com"
@@ -23,12 +23,18 @@ gcpProjectConfig:
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
+    - "serviceusage.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  serviceUsage:
+    bigQuery:
+      overrideBigQueryDailyUsageQuota: true
+      bigQueryDailyUsageQuotaOverrideValueMebibytes: 38146972 # 40 TB
+  securityGroup: "high"

--- a/src/main/resources/config/staging/pool_schema.yml
+++ b/src/main/resources/config/staging/pool_schema.yml
@@ -1,12 +1,12 @@
 # Resource Buffer Service Pools Schema in staging environment
 ---
 poolConfigs:
-  - poolId: "cwb_ws_staging_v6"
+  - poolId: "cwb_ws_staging_v7"
     size: 100
-    resourceConfigName: "cwb_ws_resource_staging_v6"
+    resourceConfigName: "cwb_ws_resource_staging_v7"
   - poolId: "datarepo_v1"
     size: 300
     resourceConfigName: "datarepo_v1"
-  - poolId: "vpc_sc_v5"
+  - poolId: "vpc_sc_v6"
     size: 100
-    resourceConfigName: "vpc_sc_v5"
+    resourceConfigName: "vpc_sc_v6"

--- a/src/main/resources/config/staging/resource-config/cwb_ws_resource_staging_v7.yml
+++ b/src/main/resources/config/staging/resource-config/cwb_ws_resource_staging_v7.yml
@@ -1,0 +1,32 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_resource_staging_v6"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-staging"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/staging/CommunityWorkbench
+  parentFolderId: "137690849844"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/staging/resource-config/cwb_ws_resource_staging_v7.yml
+++ b/src/main/resources/config/staging/resource-config/cwb_ws_resource_staging_v7.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "cwb_ws_resource_staging_v6"
+configName: "cwb_ws_resource_staging_v7"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-staging"

--- a/src/main/resources/config/staging/resource-config/vpc_sc_v6.yml
+++ b/src/main/resources/config/staging/resource-config/vpc_sc_v6.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "vpc_sc_v5"
+configName: "vpc_sc_v6"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-vpc-sc-staging"

--- a/src/main/resources/config/staging/resource-config/vpc_sc_v6.yml
+++ b/src/main/resources/config/staging/resource-config/vpc_sc_v6.yml
@@ -1,0 +1,34 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_v5"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-staging"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/staging/for_vpc_sc_unclaimed
+  parentFolderId: "119547684332"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -1,21 +1,18 @@
 # RBS Pools Schema in tools environment
 ---
 poolConfigs:
-  - poolId: "cwb_ws_fiab_v6"
+  - poolId: "cwb_ws_fiab_v7"
     size: 500
-    resourceConfigName: "cwb_ws_resource_fiab_v6"
-  - poolId: "cwb_ws_quality_v6"
+    resourceConfigName: "cwb_ws_resource_fiab_v7"
+  - poolId: "cwb_ws_quality_v8"
     size: 5000
-    resourceConfigName: "cwb_ws_resource_quality_v6"
-  - poolId: "cwb_ws_quality_v7"
-    size: 5000
-    resourceConfigName: "cwb_ws_resource_quality_v7"
+    resourceConfigName: "cwb_ws_resource_quality_v8"
   - poolId: "datarepo_v1"
     size: 1000
     resourceConfigName: "datarepo_v1"
-  - poolId: "vpc_sc_qa-fiab_v4"
+  - poolId: "vpc_sc_qa-fiab_v5"
     size: 100
-    resourceConfigName: "vpc_sc_qa-fiab_v4"
-  - poolId: "workspace_manager_v10"
+    resourceConfigName: "vpc_sc_qa-fiab_v5"
+  - poolId: "workspace_manager_v11"
     size: 500
-    resourceConfigName: "workspace_manager_v10"
+    resourceConfigName: "workspace_manager_v11"

--- a/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v7.yml
+++ b/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v7.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "cwb_ws_resource_fiab_v6"
+configName: "cwb_ws_resource_fiab_v7"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-test"

--- a/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v7.yml
+++ b/src/main/resources/config/tools/resource-config/cwb_ws_resource_fiab_v7.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# Community Workbench buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "cwb_ws_resource_fiab_v6"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-test"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # test.firecloud.org/tools/CommunityWorkbench
+  parentFolderId: "595081786611"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -25,10 +25,8 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
-    enableNetworkMonitoring: "true"
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/tools/resource-config/cwb_ws_resource_quality_v8.yml
+++ b/src/main/resources/config/tools/resource-config/cwb_ws_resource_quality_v8.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# Community Workbench buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "cwb_ws_resource_quality_v7"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-quality"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # quality.firecloud.org/quality/CommunityWorkbench
+  parentFolderId: "180789000311"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -25,10 +25,10 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
-    enableNetworkMonitoring: "true"
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/tools/resource-config/cwb_ws_resource_quality_v8.yml
+++ b/src/main/resources/config/tools/resource-config/cwb_ws_resource_quality_v8.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "cwb_ws_resource_quality_v7"
+configName: "cwb_ws_resource_quality_v8"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-quality"

--- a/src/main/resources/config/tools/resource-config/vpc_sc_dev-fiab_v5.yml
+++ b/src/main/resources/config/tools/resource-config/vpc_sc_dev-fiab_v5.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# Community Workbench buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "vpc_sc_dev-fiab_v4"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-vpc-sc-devfiab"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # test.firecloud.org/tools/for_vpc_sc_unclaimed
+  parentFolderId: "610557500976"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -25,10 +25,10 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/tools/resource-config/vpc_sc_dev-fiab_v5.yml
+++ b/src/main/resources/config/tools/resource-config/vpc_sc_dev-fiab_v5.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "vpc_sc_dev-fiab_v4"
+configName: "vpc_sc_dev-fiab_v5"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-vpc-sc-devfiab"

--- a/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v5.yml
+++ b/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v5.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# Community Workbench buffered workspace template
 ---
-configName: "resource_buffer_test_v1"
+configName: "vpc_sc_qa-fiab_v4"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-vpc-sc-qafiab"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # quality.firecloud.org/quality/for_vpc_sc_unclaimed
+  parentFolderId: "108325210767"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -25,10 +25,10 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v5.yml
+++ b/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v5.yml
@@ -1,6 +1,6 @@
 # Community Workbench buffered workspace template
 ---
-configName: "vpc_sc_qa-fiab_v4"
+configName: "vpc_sc_qa-fiab_v5"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-vpc-sc-qafiab"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v11.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v11.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v10"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-t"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "375605435272" #test.firecloud.org/tools/buffer-tools/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "bigquerydatatransfer.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "lifesciences.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "notebooks.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v11.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v11.yml
@@ -1,6 +1,6 @@
 # Workspace Manager buffered workspace template
 ---
-configName: "workspace_manager_v10"
+configName: "workspace_manager_v11"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-wsm-t"

--- a/src/main/resources/config/toolsalpha/pool_schema.yml
+++ b/src/main/resources/config/toolsalpha/pool_schema.yml
@@ -1,15 +1,6 @@
 # RBS Pools Schema for local testing and on personal environment
 ---
 poolConfigs:
-  - poolId: "resource_toolsalpha_v4"
+  - poolId: "resource_toolsalpha_v8"
     size: 5
-    resourceConfigName: "resource_toolsalpha_v4"
-  - poolId: "resource_toolsalpha_v5"
-    size: 5
-    resourceConfigName: "resource_toolsalpha_v5"
-  - poolId: "resource_toolsalpha_v6"
-    size: 5
-    resourceConfigName: "resource_toolsalpha_v6"
-  - poolId: "resource_toolsalpha_v7"
-    size: 5
-    resourceConfigName: "resource_toolsalpha_v7"
+    resourceConfigName: "resource_toolsalpha_v8"

--- a/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v8.yml
+++ b/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v8.yml
@@ -1,6 +1,6 @@
 # Resource template for local testing and personal environment on GKE
 ---
-configName: "resource_toolsalpha_v7"
+configName: "resource_toolsalpha_v8"
 gcpProjectConfig:
   projectIdSchema:
     prefix: "terra-toolsalpha"

--- a/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v8.yml
+++ b/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v8.yml
@@ -1,12 +1,12 @@
-# Resource template for running buffer service performance test
+# Resource template for local testing and personal environment on GKE
 ---
-configName: "resource_buffer_test_v1"
+configName: "resource_toolsalpha_v7"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "buffer-test"
+    prefix: "terra-toolsalpha"
     scheme: "RANDOM_CHAR"
-  # test.firecloud.org/tools/buffertest
-  parentFolderId: "339691735869"
+  # RBS Testing
+  parentFolderId: "637867149294"
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
@@ -25,10 +25,16 @@ gcpProjectConfig:
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"
     - "storage-component.googleapis.com"
-  iamBindings:
-    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
-      role: "roles/editor"
-    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
-      role: "roles/viewer"
   network:
     enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  iamBindings:
+    - members: ["group:terra-rbs-test@broadinstitute.org"]
+      role: "roles/editor"
+    - members: ["group:terra-rbs-viewer-test@broadinstitute.org"]
+      role: "roles/viewer"
+  securityGroup: "high"

--- a/src/test/java/bio/terra/buffer/config/resource-config/..data/ws_0_0_1.yml
+++ b/src/test/java/bio/terra/buffer/config/resource-config/..data/ws_0_0_1.yml
@@ -19,7 +19,6 @@ gcpProjectConfig:
     - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
-    - "genomics.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"

--- a/src/test/java/bio/terra/buffer/config/resource-config/..data/ws_0_0_2.yml
+++ b/src/test/java/bio/terra/buffer/config/resource-config/..data/ws_0_0_2.yml
@@ -19,7 +19,6 @@ gcpProjectConfig:
     - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
-    - "genomics.googleapis.com"
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"

--- a/src/test/resources/test/config/resource-config/ws_0_0_1.yml
+++ b/src/test/resources/test/config/resource-config/ws_0_0_1.yml
@@ -19,7 +19,6 @@ gcpProjectConfig:
     - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
-    - "genomics.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"

--- a/src/test/resources/test/config/resource-config/ws_0_0_2.yml
+++ b/src/test/resources/test/config/resource-config/ws_0_0_2.yml
@@ -19,7 +19,6 @@ gcpProjectConfig:
     - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
-    - "genomics.googleapis.com"
     - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"


### PR DESCRIPTION
This API blocks RBS creating new project
`Bind permission denied for service: [genomics.googleapis.com](http://genomics.googleapis.com/)\nService [genomics.googleapis.com](http://genomics.googleapis.com/) is not available to this consumer.\nHelp Token`

Ideally, we are supposed to create a new pool with a new config. However, this PR is okay because:

- That API is not used anyway. Fine to have mixed settings.
- Creating projects with the old settings is broken.
- This is quicker as we do not need another change in Rawls/WSM/firecloud-devops

**Note: Forgot if RB blocks us from updating pool config in place**