### PR TITLE
[PF-2878] - Add new wsm pool with keepDefaultNetwork

### DIFF
--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -16,3 +16,6 @@ poolConfigs:
   - poolId: "workspace_manager_v11"
     size: 500
     resourceConfigName: "workspace_manager_v11"
+  - poolId: "workspace_manager_v12"
+    size: 500
+    resourceConfigName: "workspace_manager_v12"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v12.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v12.yml
@@ -1,0 +1,31 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v11"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-d"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "bigquerydatatransfer.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "lifesciences.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    keepDefaultNetwork: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -16,3 +16,6 @@ poolConfigs:
   - poolId: "workspace_manager_v11"
     size: 500
     resourceConfigName: "workspace_manager_v11"
+  - poolId: "workspace_manager_v12"
+    size: 500
+    resourceConfigName: "workspace_manager_v12"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v12.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v12.yml
@@ -3,9 +3,9 @@
 configName: "workspace_manager_v12"
 gcpProjectConfig:
   projectIdSchema:
-    prefix: "terra-wsm-d"
+    prefix: "terra-wsm-t"
     scheme: "TWO_WORDS_NUMBER"
-  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  parentFolderId: "375605435272" #test.firecloud.org/tools/buffer-tools/workspace_manager
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"


### PR DESCRIPTION
For dataproc clusters to properly create and run in gcp projects, we need to allow inter-vm ingress traffic for the cluster nodes to properly communicate with each other.

Gcp projects come with a default network which includes the default-allow-internal firewall rule that would configure the network to our needs, but currently RBS deletes that network and uses a custom network by default.

This PR will add a new wsm pool for `dev` and `tools` environments with the `keepDefaultNetwork` config to prevent the deletion and enable the default network in provisioned projects.

Followups:
https://github.com/DataBiosphere/terra-workspace-manager/pull/1361
https://github.com/DataBiosphere/terra-resource-buffer/pull/276