### PR TITLE
DC-814: Increase datarepo tools pool size

### DIFF
--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -11,7 +11,7 @@ poolConfigs:
     size: 5000
     resourceConfigName: "cwb_ws_resource_quality_v10"
   - poolId: "datarepo_v1"
-    size: 1000
+    size: 1500
     resourceConfigName: "datarepo_v1"
   - poolId: "vpc_sc_qa-fiab_v5"
     size: 100


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-814
________
We've been seeing a lot of test flakiness around RBS over the last couple of weeks. After other debugging attempts (detailed in [datarepo PR](https://github.com/DataBiosphere/jade-data-repo/pull/1579)), I'd like to try bumping up the pool size. The recent errors have been due to not enough projects being available and the retries did not work, so potentially bumping up the pool size will provide some relief. 
 