### PR TITLE
[DCJ-284] Increase tools pool datarepo_v1 from 1500->2000

### DIFF
--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -1,4 +1,5 @@
 # RBS Pools Schema in tools environment
+# READY resource ratio by pool over time: https://grafana.dsp-devops.broadinstitute.org/goto/qHOGMufSk?orgId=1
 ---
 poolConfigs:
   - poolId: "cwb_ws_fiab_v7"
@@ -11,7 +12,7 @@ poolConfigs:
     size: 5000
     resourceConfigName: "cwb_ws_resource_quality_v10"
   - poolId: "datarepo_v1"
-    size: 1500
+    size: 2000
     resourceConfigName: "datarepo_v1"
   - poolId: "vpc_sc_qa-fiab_v5"
     size: 100


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-284

**Background**

TDR uses the `datarepo_v1` pool in RBS' tools namespace in our integration tests.  We periodically run into pool exhaustion when many test runs are running concurrently.   The configuration change we made to cancel earlier active test runs on a PR helps manage this load, but isn’t enough given the high volume of developer activity on TDR these days.

RBS logs showed a spike in related errors yesterday, aligning with many test runs that ultimately failed (we didn’t yet have pool availability metrics exposed in Grafana): https://cloudlogging.app.goo.gl/Lvwz3ytmAb1Vwx3T8

**Changes**

- Increase `datarepo_v1` pool in RBS' tools namespace from 1500 -> 2000
- Include a link to Grafana panel showing READY resource ratios for tools pools, which is getting populated as of this morning.
  - When deciding whether to modify our pool size in the past, we've wanted these metrics to be readily available to inform our decision-making.