### PR TITLE
Enable dependabot (WOR-1745).

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    open-pull-requests-limit: 10
+    groups:
+      minor-patch-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    schedule:
+      interval: "weekly"
+      time: "06:00"
+      timezone: "America/New_York"
+    target-branch: "develop"
+    reviewers:
+      - "@DataBiosphere/broadworkspaces"
+    labels:
+      - "dependency"
+      - "gradle"
+    commit-message:
+      prefix: "[WOR-1448]"


### PR DESCRIPTION
Based on the [WSM dependabot file](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/.github/dependabot.yml), though with no ignores. We can add ignores as needed.

