### PR TITLE
Switch to writing credentials from secrets for integration tests (WOR-1745).

### DIFF
--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -1,7 +1,7 @@
 name: 'write-credentials'
 description: |
-  Collect the needed credentials for testing and place them in the
-  appropriate config directory. Note that all of these secrets are
+  Collect the needed credentials for integration testing and place them in a
+  directory named "rendered". Note that all of these secrets are
   assumed to be base64-encoded JSON service account keys.
 inputs:
   buffer-app-sa-b64:
@@ -30,7 +30,4 @@ runs:
         JANITOR_SA=$(echo $JANITOR_SA_B64 | base64 --decode)
         echo ::add-mask::$JANITOR_SA
         echo $JANITOR_SA > rendered/janitor-client-sa-account.json
-        
-        echo "$(ls -d $PWD*/)"
-        echo "$(ls -l rendered)"
       shell: bash

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -1,0 +1,33 @@
+name: 'write-credentials'
+description: |
+  Collect the needed credentials for testing and place them in the
+  appropriate config directory. Note that all of these secrets are
+  assumed to be base64-encoded JSON service account keys.
+inputs:
+  buffer-app-sa-b64:
+    description: 'Base64-encoded buffer (RBS) service account'
+    required: true
+  janitor-sa-b64:
+    description: 'Base64-encoded CRL Janitor service account'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Write credentials
+      id: 'setup-user-delegated-creds'
+      run: |
+        mkdir -p rendered
+        
+        BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }} ?
+        echo ::add-mask::BUFFER_APP_SA_B64 ?
+        USER_DELEGATED_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode) ?
+        echo ::add-mask::$BUFFER_APP_SA ?
+        echo $BUFFER_APP_SA > rendered/sa-account.json
+        
+        JANITOR_SA_B64=${{ inputs.janitor-sa-b64 }}
+        echo ::add-mask::$JANITOR_SA_B64
+        JANITOR_SA=$(echo $JANITOR_SA_B64 | base64 --decode)
+        echo ::add-mask::$JANITOR_SA
+        echo $JANITOR_SA > rendered/janitor-client-sa-account.json
+      shell: bash

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -19,6 +19,8 @@ runs:
       run: |
         mkdir -p rendered
         
+        echo "$(dirname $0)"
+        
         BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
         echo ::add-mask::BUFFER_APP_SA_B64
         BUFFER_APP_SA=$(echo $BUFFER_APP_SA_B64 | base64 --decode)

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -19,10 +19,10 @@ runs:
       run: |
         mkdir -p rendered
         
-        BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }} ?
-        echo ::add-mask::BUFFER_APP_SA_B64 ?
-        USER_DELEGATED_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode) ?
-        echo ::add-mask::$BUFFER_APP_SA ?
+        BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
+        echo ::add-mask::BUFFER_APP_SA_B64
+        USER_DELEGATED_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode)
+        echo ::add-mask::$BUFFER_APP_SA
         echo $BUFFER_APP_SA > rendered/sa-account.json
         
         JANITOR_SA_B64=${{ inputs.janitor-sa-b64 }}

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -32,4 +32,6 @@ runs:
         JANITOR_SA=$(echo $JANITOR_SA_B64 | base64 --decode)
         echo ::add-mask::$JANITOR_SA
         echo $JANITOR_SA > rendered/janitor-client-sa-account.json
+        
+        echo "$ls -l rendered"
       shell: bash

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -18,6 +18,13 @@ runs:
       id: 'setup-user-delegated-creds'
       run: |
         mkdir -p rendered
+        
+        BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
+        echo ::add-mask::BUFFER_APP_SA_B64
+        BUFFER_APP_SA=$(echo $BUFFER_APP_SA_B64 | base64 --decode)
+        echo ::add-mask::$BUFFER_APP_SA
+        echo $BUFFER_APP_SA > rendered/sa-account.json  
+        
         JANITOR_SA_B64=${{ inputs.janitor-sa-b64 }}
         echo ::add-mask::$JANITOR_SA_B64
         JANITOR_SA=$(echo $JANITOR_SA_B64 | base64 --decode)

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -33,5 +33,6 @@ runs:
         echo ::add-mask::$JANITOR_SA
         echo $JANITOR_SA > rendered/janitor-client-sa-account.json
         
-        echo "$ls -l rendered"
+        echo "$(ls -d $PWD*/)"
+        echo "$(ls -l rendered)"
       shell: bash

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -18,13 +18,6 @@ runs:
       id: 'setup-user-delegated-creds'
       run: |
         mkdir -p rendered
-
-#        BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
-#        echo ::add-mask::BUFFER_APP_SA_B64
-#        BUFFER_APP_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode)
-#        echo ::add-mask::$BUFFER_APP_SA
-#        echo $BUFFER_APP_SA > rendered/sa-account.json
-
         JANITOR_SA_B64=${{ inputs.janitor-sa-b64 }}
         echo ::add-mask::$JANITOR_SA_B64
         JANITOR_SA=$(echo $JANITOR_SA_B64 | base64 --decode)

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -18,13 +18,13 @@ runs:
       id: 'setup-user-delegated-creds'
       run: |
         mkdir -p rendered
-        
-        BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
-        echo ::add-mask::BUFFER_APP_SA_B64
-        BUFFER_APP_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode)
-        echo ::add-mask::$BUFFER_APP_SA
-        echo $BUFFER_APP_SA > rendered/sa-account.json
-        
+
+#        BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
+#        echo ::add-mask::BUFFER_APP_SA_B64
+#        BUFFER_APP_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode)
+#        echo ::add-mask::$BUFFER_APP_SA
+#        echo $BUFFER_APP_SA > rendered/sa-account.json
+
         JANITOR_SA_B64=${{ inputs.janitor-sa-b64 }}
         echo ::add-mask::$JANITOR_SA_B64
         JANITOR_SA=$(echo $JANITOR_SA_B64 | base64 --decode)

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -19,8 +19,6 @@ runs:
       run: |
         mkdir -p rendered
         
-        echo "$(dirname $0)"
-        
         BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
         echo ::add-mask::BUFFER_APP_SA_B64
         BUFFER_APP_SA=$(echo $BUFFER_APP_SA_B64 | base64 --decode)

--- a/.github/actions/write-credentials/action.yml
+++ b/.github/actions/write-credentials/action.yml
@@ -21,7 +21,7 @@ runs:
         
         BUFFER_APP_SA_B64=${{ inputs.buffer-app-sa-b64 }}
         echo ::add-mask::BUFFER_APP_SA_B64
-        USER_DELEGATED_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode)
+        BUFFER_APP_SA=$(echo BUFFER_APP_SA_B64 | base64 --decode)
         echo ::add-mask::$BUFFER_APP_SA
         echo $BUFFER_APP_SA > rendered/sa-account.json
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,28 +39,13 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
-      - name: Pull Vault image
+      - name: Write credentials
         if: steps.skiptest.outputs.is-bump == 'no'
-        run: docker pull vault:1.1.0
-      # Currently, there's no way to add capabilities to Docker actions on Git, and Vault needs IPC_LOCK to run.
-      - name: Get Vault token
-        if: steps.skiptest.outputs.is-bump == 'no'
-        id: vault-token-step
-        run: |
-          VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
-            -e "VAULT_ADDR=${VAULT_ADDR}" \
-            vault:1.1.0 \
-            vault write -field token \
-              auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
-              secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
-          echo ::add-mask::$VAULT_TOKEN
-          echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
-      - name: Grant execute permission for render-config
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: chmod +x local-dev/render-config.sh
-      - name: Render configuration for tests
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: local-dev/render-config.sh ${{ steps.vault-token-step.outputs.vault-token }}
+        id: write-credentials
+        uses: ./.github/actions/write-credentials
+        with:
+          janitor-sa-b64: ${{ secrets.JANITOR_SA_DEV }}
+          buffer-app-sa-b64: ${{ secrets.BUFFER_APP_SA_DEV }}
       - name: Initialize Postgres DB
         if: steps.skiptest.outputs.is-bump == 'no'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
-      - name: Write credentials
+      - name: Write credentials for integration tests
         if: steps.skiptest.outputs.is-bump == 'no'
         id: write-credentials
         uses: ./.github/actions/write-credentials

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -6,7 +6,7 @@ test {
 
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 // This is the path to the default Google service account for the buffer service to run as.
-def googleCredentialsFile = "${projectDir}/src/test/resources/rendered/sa-account.json"
+def googleCredentialsFile = "${projectDir}/rendered/sa-account.json"
 tasks.withType(Test) {
     environment = [
             'GOOGLE_APPLICATION_CREDENTIALS': "${googleCredentialsFile}"

--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -242,8 +242,8 @@ public class CrlConfiguration {
           new FileInputStream(janitorClientCredentialFilePath));
     } catch (Exception e) {
       throw new RuntimeException(
-          "Unable to load Janitor GoogleCredentials from configuration"
-              + janitorClientCredentialFilePath,
+          "Unable to load Janitor GoogleCredentials from configuration: "
+              + janitorClientCredentialFilePath + " CWD: " + System.getProperty("user.dir"),
           e);
     }
   }

--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -241,16 +241,9 @@ public class CrlConfiguration {
       return ServiceAccountCredentials.fromStream(
           new FileInputStream(janitorClientCredentialFilePath));
     } catch (Exception e) {
-      String path = new java.io.File(janitorClientCredentialFilePath).getAbsolutePath();
-      try {
-        path = new java.io.File(janitorClientCredentialFilePath).getCanonicalPath();
-      }
-      catch (IOException ignored) {
-      }
       throw new RuntimeException(
-          "Unable to load Janitor GoogleCredentials from configuration: "
-              + janitorClientCredentialFilePath + " CWD: " + System.getProperty("user.dir") + " FILEPATH:  "
-                  + path,
+          "Unable to load Janitor GoogleCredentials from configuration"
+              + janitorClientCredentialFilePath,
           e);
     }
   }

--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -241,10 +241,16 @@ public class CrlConfiguration {
       return ServiceAccountCredentials.fromStream(
           new FileInputStream(janitorClientCredentialFilePath));
     } catch (Exception e) {
+      String path = new java.io.File(janitorClientCredentialFilePath).getAbsolutePath();
+      try {
+        path = new java.io.File(janitorClientCredentialFilePath).getCanonicalPath();
+      }
+      catch (IOException ignored) {
+      }
       throw new RuntimeException(
           "Unable to load Janitor GoogleCredentials from configuration: "
               + janitorClientCredentialFilePath + " CWD: " + System.getProperty("user.dir") + " FILEPATH:  "
-                  + new java.io.File(janitorClientCredentialFilePath).getAbsolutePath(),
+                  + path,
           e);
     }
   }

--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -243,7 +243,8 @@ public class CrlConfiguration {
     } catch (Exception e) {
       throw new RuntimeException(
           "Unable to load Janitor GoogleCredentials from configuration: "
-              + janitorClientCredentialFilePath + " CWD: " + System.getProperty("user.dir"),
+              + janitorClientCredentialFilePath + " CWD: " + System.getProperty("user.dir") + " FILEPATH:  "
+                  + new java.io.File(janitorClientCredentialFilePath).getAbsolutePath(),
           e);
     }
   }

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -3,7 +3,7 @@ buffer:
     # If CRL is used in testing mode.
     testing-mode: true
     # Use in test to clean up created cloud resource.
-    janitor-client-credential-file-path: ../../../rendered/janitor-client-sa-account.json
+    janitor-client-credential-file-path: ../../rendered/janitor-client-sa-account.json
     janitor-track-resource-project-id: terra-kernel-k8s
     janitor-track-resource-topic-id: crljanitor-tools-pubsub-topic
   pool:

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -3,7 +3,7 @@ buffer:
     # If CRL is used in testing mode.
     testing-mode: true
     # Use in test to clean up created cloud resource.
-    janitor-client-credential-file-path: ../rendered/janitor-client-sa-account.json
+    janitor-client-credential-file-path: ../../../rendered/janitor-client-sa-account.json
     janitor-track-resource-project-id: terra-kernel-k8s
     janitor-track-resource-topic-id: crljanitor-tools-pubsub-topic
   pool:

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -3,7 +3,7 @@ buffer:
     # If CRL is used in testing mode.
     testing-mode: true
     # Use in test to clean up created cloud resource.
-    janitor-client-credential-file-path: src/test/resources/rendered/janitor-client-sa-account.json
+    janitor-client-credential-file-path: ../rendered/janitor-client-sa-account.json
     janitor-track-resource-project-id: terra-kernel-k8s
     janitor-track-resource-topic-id: crljanitor-tools-pubsub-topic
   pool:

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -3,7 +3,7 @@ buffer:
     # If CRL is used in testing mode.
     testing-mode: true
     # Use in test to clean up created cloud resource.
-    janitor-client-credential-file-path: ../rendered/janitor-client-sa-account.json
+    janitor-client-credential-file-path: src/test/resources/rendered/janitor-client-sa-account.json
     janitor-track-resource-project-id: terra-kernel-k8s
     janitor-track-resource-topic-id: crljanitor-tools-pubsub-topic
   pool:

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -3,7 +3,7 @@ buffer:
     # If CRL is used in testing mode.
     testing-mode: true
     # Use in test to clean up created cloud resource.
-    janitor-client-credential-file-path: ../../_temp/rendered/janitor-client-sa-account.json
+    janitor-client-credential-file-path: rendered/janitor-client-sa-account.json
     janitor-track-resource-project-id: terra-kernel-k8s
     janitor-track-resource-topic-id: crljanitor-tools-pubsub-topic
   pool:

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -3,7 +3,7 @@ buffer:
     # If CRL is used in testing mode.
     testing-mode: true
     # Use in test to clean up created cloud resource.
-    janitor-client-credential-file-path: ../../rendered/janitor-client-sa-account.json
+    janitor-client-credential-file-path: ../../_temp/rendered/janitor-client-sa-account.json
     janitor-track-resource-project-id: terra-kernel-k8s
     janitor-track-resource-topic-id: crljanitor-tools-pubsub-topic
   pool:


### PR DESCRIPTION
As part of [WOR-1745](https://broadworkbench.atlassian.net/browse/WOR-1745), we need to change how the CI pipeline gets the SA credentials so that dependabot is able to run the tests (related PR is https://github.com/broadinstitute/terraform-ap-deployments/pull/1623).

[WOR-1745]: https://broadworkbench.atlassian.net/browse/WOR-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ