### PR TITLE
[WOR-1744] Switch resource counter to gauge and bump TCL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ repositories {
 
 dependencies {
     // Terra deps - we get Stairway via TCL
-    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.17-SNAPSHOT'
+    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.18-SNAPSHOT'
     implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.30-SNAPSHOT'
     implementation group: 'bio.terra', name: 'terra-resource-janitor-client', version: '0.114.0-SNAPSHOT'
 

--- a/src/test/java/bio/terra/buffer/common/MetricsHelperTest.java
+++ b/src/test/java/bio/terra/buffer/common/MetricsHelperTest.java
@@ -87,7 +87,7 @@ public class MetricsHelperTest extends BaseUnitTest {
                   .forEach(
                       state -> {
                         var dataPoint =
-                            (LongPointData)
+                            (DoublePointData)
                                 metricsByName
                                     .get(RESOURCE_STATE_COUNT_METER_NAME)
                                     .getData()


### PR DESCRIPTION
Ticket: [WOR-1744](https://broadworkbench.atlassian.net/browse/WOR-1744)
* Switch resource counter to gauge to report current resource counts instead of total number of resources in each count over pod lifespan
* Bump TCL version to pull in fix from https://github.com/DataBiosphere/terra-common-lib/pull/197 

Counter before would increase by the count of resources in a given state every time metrics were recorded (pool size of 5):
```
terra_buffer_resource_resource_state_count_num_per_pool_total{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="CREATING"} 71.0
terra_buffer_resource_resource_state_count_num_per_pool_total{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="DELETED"} 0.0
terra_buffer_resource_resource_state_count_num_per_pool_total{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="DELETING"} 0.0
terra_buffer_resource_resource_state_count_num_per_pool_total{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="HANDED_OUT"} 0.0
terra_buffer_resource_resource_state_count_num_per_pool_total{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="READY"} 104.0
```
Now the gauge reports the number of resources currently in a given state (same pool size):
```
terra_buffer_resource_resource_state_count_num_per_pool{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="CREATING"} 3.0
terra_buffer_resource_resource_state_count_num_per_pool{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="DELETED"} 0.0
terra_buffer_resource_resource_state_count_num_per_pool{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="DELETING"} 0.0
terra_buffer_resource_resource_state_count_num_per_pool{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="HANDED_OUT"} 0.0
terra_buffer_resource_resource_state_count_num_per_pool{otel_scope_name="bio.terra.common.stairway.MetricsHelper",pool_id="resource_toolsalpha_v8",pool_status="ACTIVE",resource_state="READY"} 2.0
```

[WOR-1744]: https://broadworkbench.atlassian.net/browse/WOR-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ