### PR TITLE
[WOR-1811] Set tools version when merging to master

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -113,3 +113,17 @@ jobs:
       sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
     permissions:
       id-token: 'write'
+
+  set-version-in-tools:
+    # Put new RBS version in Broad tools environment
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [tag-build-push, report-to-sherlock]
+    if: ${{ needs.tag-build-push.outputs.is-bump == 'no' }}
+    with:
+      new-version: ${{ needs.tag-build-push.outputs.tag }}
+      chart-name: 'buffer'
+      environment-name: 'tools'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'


### PR DESCRIPTION
Ticket: [WOR-1811](https://broadworkbench.atlassian.net/browse/WOR-1811)
* duplicate step in GHA workflow that sets dev version to also set tools version which is used by BEEs

[WOR-1811]: https://broadworkbench.atlassian.net/browse/WOR-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ