### PR TITLE
[WOR-1816] Scheduled DB cleanup job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation group: 'bio.terra', name: 'terra-resource-janitor-client', version: '0.114.0-SNAPSHOT'
 
     // Versioned direct deps
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.16.0'
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '5.16.0'
     implementation group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.11.0'
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.132.2'
     implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'

--- a/src/main/java/bio/terra/buffer/app/StartupInitializer.java
+++ b/src/main/java/bio/terra/buffer/app/StartupInitializer.java
@@ -3,7 +3,8 @@ package bio.terra.buffer.app;
 import bio.terra.buffer.app.configuration.BufferDatabaseConfiguration;
 import bio.terra.buffer.app.configuration.BufferDatabaseProperties;
 import bio.terra.buffer.app.configuration.StairwayDatabaseConfiguration;
-import bio.terra.buffer.service.cleanup.CleanupScheduler;
+import bio.terra.buffer.db.DbCleanupJob;
+import bio.terra.buffer.service.cleanup.JanitorResourceCleanupScheduler;
 import bio.terra.buffer.service.pool.PoolService;
 import bio.terra.buffer.service.resource.FlightScheduler;
 import bio.terra.common.migrate.LiquibaseMigrator;
@@ -42,7 +43,8 @@ public final class StartupInitializer {
     initializeStairwayComponent(applicationContext);
     applicationContext.getBean(PoolService.class).initialize();
     applicationContext.getBean(FlightScheduler.class).initialize();
-    applicationContext.getBean(CleanupScheduler.class).initialize();
+    applicationContext.getBean(JanitorResourceCleanupScheduler.class).initialize();
+    applicationContext.getBean(DbCleanupJob.class).initialize();
   }
 
   // Initialize StairwayComponent's DataSource. This is necessary because the data source is

--- a/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/CrlConfiguration.java
@@ -46,6 +46,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class CrlConfiguration {
   /** The client name required by CRL. */
   public static final String CLIENT_NAME = "terra-resource-buffer";
+
   /**
    * Whether we're running Resource Buffer Service in test mode with Cloud Resource Library. If so,
    * we enable to the Janitor to auto-delete all created cloud resources.

--- a/src/main/java/bio/terra/buffer/app/configuration/DbCleanupJobConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/DbCleanupJobConfiguration.java
@@ -1,0 +1,46 @@
+package bio.terra.buffer.app.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "buffer.db.cleanup-job")
+public class DbCleanupJobConfiguration {
+
+  private String schedule;
+  private boolean enabled;
+  private int retentionDays;
+  private int batchSize;
+
+  public String getSchedule() {
+    return schedule;
+  }
+
+  public void setSchedule(String schedule) {
+    this.schedule = schedule;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getRetentionDays() {
+    return retentionDays;
+  }
+
+  public void setRetentionDays(int retentionDays) {
+    this.retentionDays = retentionDays;
+  }
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+}

--- a/src/main/java/bio/terra/buffer/app/configuration/ShedlockConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/ShedlockConfiguration.java
@@ -18,19 +18,19 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableSchedulerLock(defaultLockAtMostFor = "PT4H")
 public class ShedlockConfiguration {
 
-    private final JdbcTemplate jdbcTemplate;
+  private final JdbcTemplate jdbcTemplate;
 
-    @Autowired
-    public ShedlockConfiguration(BufferDatabaseConfiguration jdbcConfiguration) {
-        this.jdbcTemplate = new JdbcTemplate(jdbcConfiguration.getDataSource());
-    }
+  @Autowired
+  public ShedlockConfiguration(BufferDatabaseConfiguration jdbcConfiguration) {
+    this.jdbcTemplate = new JdbcTemplate(jdbcConfiguration.getDataSource());
+  }
 
-    @Bean
-    public LockProvider lockProvider() {
-        return new JdbcTemplateLockProvider(
-                JdbcTemplateLockProvider.Configuration.builder()
-                        .withJdbcTemplate(jdbcTemplate)
-                        .usingDbTime()
-                        .build());
-    }
+  @Bean
+  public LockProvider lockProvider() {
+    return new JdbcTemplateLockProvider(
+        JdbcTemplateLockProvider.Configuration.builder()
+            .withJdbcTemplate(jdbcTemplate)
+            .usingDbTime()
+            .build());
+  }
 }

--- a/src/main/java/bio/terra/buffer/app/configuration/ShedlockConfiguration.java
+++ b/src/main/java/bio/terra/buffer/app/configuration/ShedlockConfiguration.java
@@ -1,0 +1,36 @@
+package bio.terra.buffer.app.configuration;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Configures shedlock for scheduling background jobs within a multi-instance environment. This
+ * allows us to ensure that scheduled tasks are executed at most once at the same time.
+ */
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT4H")
+public class ShedlockConfiguration {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ShedlockConfiguration(BufferDatabaseConfiguration jdbcConfiguration) {
+        this.jdbcTemplate = new JdbcTemplate(jdbcConfiguration.getDataSource());
+    }
+
+    @Bean
+    public LockProvider lockProvider() {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(jdbcTemplate)
+                        .usingDbTime()
+                        .build());
+    }
+}

--- a/src/main/java/bio/terra/buffer/common/MetricsHelper.java
+++ b/src/main/java/bio/terra/buffer/common/MetricsHelper.java
@@ -27,6 +27,7 @@ public class MetricsHelper implements AutoCloseable {
 
   /** Unit string for count. */
   private static final String COUNT = "1";
+
   /** Unit string for resource count to pool size ratio. */
   private static final String RESOURCE_TO_POOL_SIZE_RATIO = "num/pool";
 
@@ -42,7 +43,9 @@ public class MetricsHelper implements AutoCloseable {
    */
   private final ConcurrentHashMap<String, Double> currentReadyRatioByPoolId =
       new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<Pool, Multiset<ResourceState>> currentResourceStatesByPool = new ConcurrentHashMap<>();
+
+  private final ConcurrentHashMap<Pool, Multiset<ResourceState>> currentResourceStatesByPool =
+      new ConcurrentHashMap<>();
 
   public MetricsHelper(OpenTelemetry openTelemetry) {
     var meter = openTelemetry.getMeter(bio.terra.common.stairway.MetricsHelper.class.getName());

--- a/src/main/java/bio/terra/buffer/db/BufferDao.java
+++ b/src/main/java/bio/terra/buffer/db/BufferDao.java
@@ -416,7 +416,10 @@ public class BufferDao {
     jdbcTemplate.update(sql, params);
   }
 
-  /** TODO document */
+  /**
+   * Inserts a record into cleanup_record table with creation timestamp. This is a convenience
+   * method for testing
+   */
   @VisibleForTesting
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public void insertCleanupRecordWithCreationTimestamp(ResourceId resourceId, Instant creation) {
@@ -468,6 +471,15 @@ public class BufferDao {
     return jdbcTemplate.query(sqlBuilder.toString(), params, RESOURCE_ROW_MAPPER);
   }
 
+  /**
+   * Given a retention period, remove dead resource records that are either: 1) handed out and older
+   * than the retention period, or 2) marked as deleted
+   *
+   * @param retentionDays retention period in days for handed out resource records before they are
+   *     eligible for deletion
+   * @param batchSize number of records to delete in one batch
+   * @return number of records deleted
+   */
   @Transactional
   public int removeDeadResourceRecords(int retentionDays, int batchSize) {
     String sql =
@@ -490,6 +502,14 @@ public class BufferDao {
     return jdbcTemplate.update(sql, params);
   }
 
+  /**
+   * Given a retention period, remove dead cleanup records that are older than the retention period.
+   *
+   * @param retentionDays retention period in days for cleanup records before they are eligible for
+   *     deletion
+   * @param batchSize number of records to delete in one batch
+   * @return number of records deleted
+   */
   @Transactional
   public int removeDeadCleanupRecords(int retentionDays, int batchSize) {
     String sql =

--- a/src/main/java/bio/terra/buffer/db/BufferDao.java
+++ b/src/main/java/bio/terra/buffer/db/BufferDao.java
@@ -19,6 +19,7 @@ import bio.terra.common.exception.InternalServerErrorException;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -290,6 +291,17 @@ public class BufferDao {
     return jdbcTemplate.update(sql, params) == 1;
   }
 
+  @VisibleForTesting
+  @Transactional
+  public void updateResourceHandoutTime(ResourceId id, Instant handoutTime) {
+    String sql = "UPDATE resource SET handout_time = :handout_time WHERE id = :id";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("handout_time", handoutTime.atOffset(ZoneOffset.UTC))
+            .addValue("id", id.id());
+    jdbcTemplate.update(sql, params);
+  }
+
   /**
    * Pick one READY resource and handed it out to client. The steps are:
    *
@@ -404,6 +416,20 @@ public class BufferDao {
     jdbcTemplate.update(sql, params);
   }
 
+  /** TODO document */
+  @VisibleForTesting
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void insertCleanupRecordWithCreationTimestamp(ResourceId resourceId, Instant creation) {
+    String sql =
+        "INSERT INTO cleanup_record (resource_id, created_at) values (:resource_id, :created_at)";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("resource_id", resourceId.id())
+            .addValue("created_at", OffsetDateTime.ofInstant(creation, ZoneOffset.UTC));
+
+    jdbcTemplate.update(sql, params);
+  }
+
   /**
    * Retrieves resources that need cleanup by Janitor. Those resources should be:
    *
@@ -440,6 +466,44 @@ public class BufferDao {
             .addValue("limit", limit);
 
     return jdbcTemplate.query(sqlBuilder.toString(), params, RESOURCE_ROW_MAPPER);
+  }
+
+  @Transactional
+  public int removeDeadResourceRecords(int retentionDays, int batchSize) {
+    String sql =
+        "DELETE FROM resource WHERE id IN ("
+            + "SELECT id FROM resource "
+            + "WHERE state IN (:handedOutState, :deletedState) AND "
+            + " ("
+            + "     (state = :handedOutState AND handout_time < NOW() - MAKE_INTERVAL(days => :retentionDays)) OR "
+            + "     (state = :deletedState) "
+            + " ) "
+            + "LIMIT :batchSize "
+            + ")";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("handedOutState", ResourceState.HANDED_OUT.toString())
+            .addValue("deletedState", ResourceState.DELETED.toString())
+            .addValue("retentionDays", retentionDays)
+            .addValue("batchSize", batchSize);
+
+    return jdbcTemplate.update(sql, params);
+  }
+
+  @Transactional
+  public int removeDeadCleanupRecords(int retentionDays, int batchSize) {
+    String sql =
+        "DELETE FROM cleanup_record WHERE resource_id IN ("
+            + "SELECT resource_id FROM cleanup_record "
+            + "WHERE created_at < NOW() - MAKE_INTERVAL(days => :retentionDays) "
+            + "LIMIT :batchSize "
+            + ")";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("retentionDays", retentionDays)
+            .addValue("batchSize", batchSize);
+
+    return jdbcTemplate.update(sql, params);
   }
 
   private static final RowMapper<Pool> POOL_ROW_MAPPER =

--- a/src/main/java/bio/terra/buffer/db/DbCleanupJob.java
+++ b/src/main/java/bio/terra/buffer/db/DbCleanupJob.java
@@ -1,0 +1,69 @@
+package bio.terra.buffer.db;
+
+import bio.terra.buffer.app.configuration.DbCleanupJobConfiguration;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodically cleans up the resource and cleanup_record tables by removing records that are
+ * either: 1) Deleted 2) Handed-out, and older than the configured retention period
+ */
+@Component
+public class DbCleanupJob {
+
+  private final Logger logger = LoggerFactory.getLogger(DbCleanupJob.class);
+  private final BufferDao bufferDao;
+  private final DbCleanupJobConfiguration config;
+
+  @Autowired
+  public DbCleanupJob(BufferDao bufferDao, DbCleanupJobConfiguration config) {
+    this.bufferDao = bufferDao;
+    this.config = config;
+  }
+
+  /** Initialize any job related resources. For now, we are just logging configuration. */
+  public void initialize() {
+    logger.info("DB table cleanup job enabled = {}", config.isEnabled());
+    logger.info("DB table cleanup job schedule = {}", config.getSchedule());
+  }
+
+  @Scheduled(cron = "${buffer.db.cleanup-job.schedule}")
+  @SchedulerLock(name = "Table Cleanup Job", lockAtMostFor = "PT1H")
+  public void tableCleanupJob() {
+    if (!config.isEnabled()) {
+      logger.info("DB table cleanup job scheduled to run but job is disabled, skipping this run.");
+      return;
+    }
+
+    if (config.getRetentionDays() <= 0) {
+      logger.warn(
+          "DB table cleanup job scheduled to run but retention days is <= 0, skipping this run.");
+      return;
+    }
+
+    if (config.getBatchSize() <= 0) {
+      logger.warn(
+          "DB table cleanup job scheduled to run but batch size is <= 0, skipping this run.");
+      return;
+    }
+
+    // Cleanup resource table
+    logger.info("Starting DB table cleanup job");
+    logger.info("DB dead resource records older than {} days", config.getRetentionDays());
+    var deletedResourceRecords =
+        bufferDao.removeDeadResourceRecords(config.getRetentionDays(), config.getBatchSize());
+    logger.info("DB table cleanup job removed = {} dead resource records", deletedResourceRecords);
+
+    // cleanup the cleanup_record table
+    logger.info("DB dead cleanup records older than {} days", config.getRetentionDays());
+    var deletedCleanupRecords =
+        bufferDao.removeDeadCleanupRecords(config.getRetentionDays(), config.getBatchSize());
+    logger.info("DB table cleanup job removed = {} dead cleanup records", deletedCleanupRecords);
+
+    logger.info("DB table cleanup job completed");
+  }
+}

--- a/src/main/java/bio/terra/buffer/service/cleanup/JanitorResourceCleanupScheduler.java
+++ b/src/main/java/bio/terra/buffer/service/cleanup/JanitorResourceCleanupScheduler.java
@@ -33,11 +33,11 @@ import org.springframework.stereotype.Component;
 
 /** Scheduler service to publish message to Janitor to cleanup resource. */
 @Component
-public class CleanupScheduler {
+public class JanitorResourceCleanupScheduler {
   // Number of message to publish per scheduler run.
   private static final Integer MESSAGE_TO_PUBLISH_PER_RUN = 100;
 
-  private final Logger logger = LoggerFactory.getLogger(CleanupScheduler.class);
+  private final Logger logger = LoggerFactory.getLogger(JanitorResourceCleanupScheduler.class);
 
   /** Only need as many threads as we have scheduled tasks. */
   private final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
@@ -50,7 +50,8 @@ public class CleanupScheduler {
   private Publisher publisher;
 
   @Autowired
-  public CleanupScheduler(BufferDao bufferDao, CrlConfiguration crlConfiguration, Clock clock) {
+  public JanitorResourceCleanupScheduler(
+      BufferDao bufferDao, CrlConfiguration crlConfiguration, Clock clock) {
     this.bufferDao = bufferDao;
     this.crlConfiguration = crlConfiguration;
     this.clock = clock;

--- a/src/main/java/bio/terra/buffer/service/pool/PoolConfigLoader.java
+++ b/src/main/java/bio/terra/buffer/service/pool/PoolConfigLoader.java
@@ -34,6 +34,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 public class PoolConfigLoader {
   /** Pool schema file name should be the same name for all environments. */
   private static final String POOL_SCHEMA_NAME = "pool_schema.yml";
+
   /** Resource configs folder name should be the same name for all environments. */
   private static final String RESOURCE_CONFIG_SUB_DIR_NAME = "resource-config";
 

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateProjectStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateProjectStep.java
@@ -42,11 +42,13 @@ public class CreateProjectStep implements Step {
   @VisibleForTesting public static final String CONFIG_NAME_LABEL_KEY = "buffer-config-name";
   // GKE default service account name label. Only sets when createGkeDefaultServiceAccount is true.
   @VisibleForTesting public static final String GKE_DEFAULT_SA_LABEL_KEY = "gke-default-sa";
+
   // Firewall rule name to allow https traffic for leonardo VMs. Empty if not having such firewall
   // rule.
   @VisibleForTesting
   public static final String LEONARDO_ALLOW_HTTPS_FIREWALL_RULE_NAME_LABEL_KEY =
       "leonardo-allow-https-firewall-name";
+
   // Firewall rule name to allow internal traffic within VPC for leonardo VMs. Empty if not having
   // such firewall rule.
   @VisibleForTesting

--- a/src/main/java/bio/terra/buffer/service/resource/flight/CreateRouterNatStep.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/CreateRouterNatStep.java
@@ -39,9 +39,11 @@ public class CreateRouterNatStep implements Step {
   private static final Logger LOGGER = LoggerFactory.getLogger(CreateRouterNatStep.class);
   private final GcpProjectConfig gcpProjectConfig;
   private final CloudComputeCow computeCow;
+
   /** All of the IP ranges in every Subnetwork are allowed to Nat. */
   @VisibleForTesting
   public static final String SUBNETWORK_IP_RANGES_TO_NAT = "ALL_SUBNETWORKS_ALL_IP_RANGES";
+
   /** Nat IPs are allocated by Google Cloud Platform; customers can't specify any Nat IPs. */
   @VisibleForTesting public static final String NAT_IP_ALLOCATION = "AUTO_ONLY";
 

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectConfigUtils.java
@@ -182,6 +182,7 @@ public class GoogleProjectConfigUtils {
         .filter(e -> !blockedRegions.contains(e.getKey()))
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
   }
+
   /** append target tags for VM instances that should be applied the internal ingress rules. */
   public static Firewall appendInternalIngressTargetTags(
       Firewall firewall, GcpProjectConfig gcpProjectConfig) {

--- a/src/main/java/bio/terra/buffer/service/resource/flight/GoogleUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleUtils.java
@@ -25,6 +25,7 @@ public class GoogleUtils {
   /** The private DNS zone name for GCR. */
   @VisibleForTesting
   public static final String GCR_MANAGED_ZONE_NAME = "private-google-access-gcr-dns-zone";
+
   /** The private DNS zone name for GAR. */
   public static final String GAR_MANAGED_ZONE_NAME = "private-google-access-gar-dns-zone";
 

--- a/src/main/java/bio/terra/buffer/service/resource/flight/StepUtils.java
+++ b/src/main/java/bio/terra/buffer/service/resource/flight/StepUtils.java
@@ -18,7 +18,7 @@ public class StepUtils {
    * outrage, and other unknown issues.
    */
   public static RetryRuleFixedInterval newCloudApiDefaultRetryRule() {
-    return new RetryRuleFixedInterval(/* intervalSeconds =*/ 60, /* maxCount =*/ 10);
+    return new RetryRuleFixedInterval(/* intervalSeconds= */ 60, /* maxCount= */ 10);
   }
 
   /**
@@ -26,7 +26,7 @@ public class StepUtils {
    * they all internal operations, e.g. DB write/read. And we are able to retry right away.
    */
   public static RetryRuleFixedInterval newInternalDefaultRetryRule() {
-    return new RetryRuleFixedInterval(/* intervalSeconds =*/ 5, /* maxCount =*/ 10);
+    return new RetryRuleFixedInterval(/* intervalSeconds= */ 5, /* maxCount= */ 10);
   }
 
   /** Update resource state to READY and update working map's RESOURCE_READY boolean value. */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ buffer:
     username:
     cleanup-job:
       enabled: false
-      schedule: 0 0 4 * * * # every day at 4 am
+      schedule: 0 0 10 * * * # every day at 4 am
       retention-days: 30
       batch-size: 1000
   primary:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ buffer:
     username:
     cleanup-job:
       enabled: false
-      schedule: 0 0 10 * * * # every day at 4 am
+      schedule: 0 0 10 * * * # every day at 10 am
       retention-days: 30
       batch-size: 1000
   primary:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,16 @@
 buffer:
   db:
+
     password:
     recreate-db-on-start: false
     update-db-on-start: true
     uri: jdbc:postgresql://127.0.0.1:5432/${BUFFER_DATABASE_NAME}
     username:
+    cleanup-job:
+      enabled: false
+      schedule: 0 0 4 * * * # every day at 4 am
+      retention-days: 30
+      batch-size: 1000
   primary:
     scheduler-enabled: true
   pool:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -3,4 +3,5 @@
     <include file="changesets/20200925_initial_schema.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20210405_add_resource_state_index.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20240926_shedlock.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240926_add_cleanup_created_at.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -2,4 +2,5 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <include file="changesets/20200925_initial_schema.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20210405_add_resource_state_index.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240926_shedlock.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20240926_add_cleanup_created_at.yaml
+++ b/src/main/resources/db/changesets/20240926_add_cleanup_created_at.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_cleanup_created_at_timestamp
+      author: aherbst
+      comment: Add created_at column to cleanup_record table so we can periodically clean it out
+      changes:
+        - addColumn:
+            tableName: cleanup_record
+            column:
+              name: created_at
+              type: timestamptz
+              constraints:
+                nullable: false
+              defaultValueComputed: CURRENT_TIMESTAMP
+
+        - createIndex:
+            indexName: created_at_index
+            tableName: cleanup_record
+            column:
+              name: created_at

--- a/src/main/resources/db/changesets/20240926_shedlock.yaml
+++ b/src/main/resources/db/changesets/20240926_shedlock.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: init_shedlock_table
+      author: aherbst
+      comment: Create the shedlock table for scheduled job locking
+      changes:
+        - createTable:
+            tableName: shedlock
+            columns:
+              - column:
+                  name: name
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  name: lock_until
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_by
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false

--- a/src/test/java/bio/terra/buffer/config/PoolSchemaTest.java
+++ b/src/test/java/bio/terra/buffer/config/PoolSchemaTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 public class PoolSchemaTest {
   private static final String CONFIG_FOLDER = "config/";
+
   /** List of pool config folders for all environments, e.g. prod, staging, dev. */
   private static final List<String> POOL_CONFIG_FOLDERS =
       ImmutableList.of(

--- a/src/test/java/bio/terra/buffer/db/DbCleanupJobTest.java
+++ b/src/test/java/bio/terra/buffer/db/DbCleanupJobTest.java
@@ -1,0 +1,77 @@
+package bio.terra.buffer.db;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import bio.terra.buffer.app.configuration.DbCleanupJobConfiguration;
+import bio.terra.buffer.common.BaseUnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DbCleanupJobTest extends BaseUnitTest {
+
+  private BufferDao bufferDao;
+  private DbCleanupJobConfiguration dbCleanupJobConfiguration;
+  private DbCleanupJob dbCleanupJob;
+
+  @BeforeEach
+  void setup() {
+    bufferDao = mock(BufferDao.class);
+    dbCleanupJobConfiguration = new DbCleanupJobConfiguration();
+    dbCleanupJob = new DbCleanupJob(bufferDao, dbCleanupJobConfiguration);
+  }
+
+  @Test
+  void testTableCleanupJob() {
+    dbCleanupJobConfiguration.setEnabled(true);
+    dbCleanupJobConfiguration.setRetentionDays(10);
+    dbCleanupJobConfiguration.setBatchSize(100);
+
+    dbCleanupJob.tableCleanupJob();
+
+    verify(bufferDao)
+        .removeDeadCleanupRecords(
+            dbCleanupJobConfiguration.getRetentionDays(), dbCleanupJobConfiguration.getBatchSize());
+    verify(bufferDao)
+        .removeDeadResourceRecords(
+            dbCleanupJobConfiguration.getRetentionDays(), dbCleanupJobConfiguration.getBatchSize());
+  }
+
+  @Test
+  void testTableCleanupJob_doesNothingWhenDisabled() {
+    dbCleanupJobConfiguration.setEnabled(false);
+    dbCleanupJobConfiguration.setRetentionDays(10);
+    dbCleanupJobConfiguration.setBatchSize(100);
+
+    dbCleanupJob.tableCleanupJob();
+
+    verify(bufferDao, never()).removeDeadCleanupRecords(anyInt(), anyInt());
+    verify(bufferDao, never()).removeDeadResourceRecords(anyInt(), anyInt());
+  }
+
+  @Test
+  void testTableCleanupJob_doesNothingWithNoRetentionDays() {
+    dbCleanupJobConfiguration.setEnabled(true);
+    dbCleanupJobConfiguration.setRetentionDays(0);
+    dbCleanupJobConfiguration.setBatchSize(100);
+
+    dbCleanupJob.tableCleanupJob();
+
+    verify(bufferDao, never()).removeDeadCleanupRecords(anyInt(), anyInt());
+    verify(bufferDao, never()).removeDeadResourceRecords(anyInt(), anyInt());
+  }
+
+  @Test
+  void testTableCleanupJob_doesNothingWithNoBatchSize() {
+    dbCleanupJobConfiguration.setEnabled(true);
+    dbCleanupJobConfiguration.setRetentionDays(10);
+    dbCleanupJobConfiguration.setBatchSize(0);
+
+    dbCleanupJob.tableCleanupJob();
+
+    verify(bufferDao, never()).removeDeadCleanupRecords(anyInt(), anyInt());
+    verify(bufferDao, never()).removeDeadResourceRecords(anyInt(), anyInt());
+  }
+}

--- a/src/test/java/bio/terra/buffer/integration/IntegrationUtils.java
+++ b/src/test/java/bio/terra/buffer/integration/IntegrationUtils.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 public class IntegrationUtils {
   /** The folder to create project within in test. */
   public static final String FOLDER_ID = "637867149294";
+
   /** The billing account to use in test. */
   public static final String BILLING_ACCOUNT_NAME = "01A82E-CA8A14-367457";
 

--- a/src/test/java/bio/terra/buffer/service/cleanup/CleanupSchedulerTest.java
+++ b/src/test/java/bio/terra/buffer/service/cleanup/CleanupSchedulerTest.java
@@ -65,7 +65,7 @@ public class CleanupSchedulerTest extends BaseUnitTest {
   @Autowired BufferDao bufferDao;
 
   private CrlConfiguration crlConfiguration = new CrlConfiguration();
-  private CleanupScheduler cleanupScheduler;
+  private JanitorResourceCleanupScheduler cleanupScheduler;
   private ObjectMapper objectMapper =
       new ObjectMapper()
           .registerModule(new Jdk8Module())
@@ -81,7 +81,8 @@ public class CleanupSchedulerTest extends BaseUnitTest {
     crlConfiguration.setJanitorTrackResourceTopicId("topicId");
     crlConfiguration.setTestResourceTimeToLive(Duration.ofHours(10));
     cleanupScheduler =
-        new CleanupScheduler(bufferDao, crlConfiguration, Clock.fixed(CREATION, ZoneId.of("UTC")));
+        new JanitorResourceCleanupScheduler(
+            bufferDao, crlConfiguration, Clock.fixed(CREATION, ZoneId.of("UTC")));
     cleanupScheduler.providePublisher(mockPublisher);
     when(mockPublisher.publish(any())).thenReturn(mockMessageIdFuture);
     when(mockMessageIdFuture.get()).thenReturn("message");


### PR DESCRIPTION
## Context
The `resource` and `cleanup_record` tables are only ever appended to, and grow without bound. This can cause performance issues as the DB eventually struggles to manage these ever-larger tables.

## This PR
* I've introduced a scheduled job that will find all records in these tables and delete those that are eligible for cleanup, up to a limit. This job is scheduled via Spring's [scheduling](https://spring.io/guides/gs/scheduling-tasks) mechanism. This introduces a divergence from the current pattern in the codebase of [using](https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/cleanup/CleanupScheduler.java#L43) a [ScheduledExecutorService](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ScheduledExecutorService.html). I've opted for the spring mechanism primarily for ease-of-use and a more grok-able cron scheduling configuration that plays well with spring's configuration framework. 
    * The `cleanup_record` table does not have any usable timestamps to determine when a record is eligible for cleanup. So, I've added one in [this](https://github.com/DataBiosphere/terra-resource-buffer/pull/353/files#diff-1f5abc82d32af500cac1b822676a7d4755fa2a17ab71aaec487add2d8bbaa9a5) changeset.
* Since the scheduled tasks will run on any node in a k8s cluster, a locking mechanism is required to prevent unwanted concurrent execution of this job. I've leveraged [Shedlock](https://github.com/lukas-krecan/ShedLock/tree/master) to manage this and ensure at most once execution per scheduled tick. 
   * Shedlock requires a table to track locking, which I've added in [this](https://github.com/DataBiosphere/terra-resource-buffer/pull/353/files#diff-c019a2563fe7b3aa6d6fb66aed8f3ffbde2dccc5c93a562efef59b9dac9a6e4a) changeset.
 * The job is configured [off by default](https://github.com/DataBiosphere/terra-resource-buffer/blob/536ef1a0fdbf685dba3007578f7cf1df08a56356/src/main/resources/application.yml#L10), it will need to be enabled via helmfile env var changes as it is rolled out per environment. 
 * I also ran spotless over the codebase to get formatting in line, there are a handful of changes that resulted from that. 