### PR TITLE
[WOR-1448] Remove protobuf-java constraint as upstream deps have upgraded to 3.25.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,6 @@ dependencies {
     // These are not directly included, they are just constrained if they are pulled in as
     // transitive dependencies.
     constraints {
-        implementation('com.google.protobuf:protobuf-java:3.21.10')
         implementation('org.yaml:snakeyaml:2.3')
         implementation('com.nimbusds:nimbus-jose-jwt:9.41.1')
         implementation('io.projectreactor.netty:reactor-netty-http:1.1.22')
@@ -124,7 +123,6 @@ if (hasProperty('buildScan')) {
 }
 
 def gradleIncDir= "$rootDir/gradle"
-apply from: "$gradleIncDir/dependency-locking.gradle"
 apply from: "$gradleIncDir/jacoco.gradle"
 apply from: "$gradleIncDir/javadoc.gradle"
 apply from: "$gradleIncDir/jib.gradle"

--- a/gradle/dependency-locking.gradle
+++ b/gradle/dependency-locking.gradle
@@ -1,3 +1,0 @@
-dependencyLocking {
-    lockAllConfigurations() // see https://docs.gradle.org/current/userguide/dependency_locking.html
-}

--- a/terra-resource-buffer-client/build.gradle
+++ b/terra-resource-buffer-client/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 }
 
 def gradleIncDir= "$rootDir/gradle"
-apply from: "$gradleIncDir/dependency-locking.gradle"
 apply from: "$gradleIncDir/publishing.gradle"
 apply from: "$gradleIncDir/swagger-client.gradle"
 


### PR DESCRIPTION
This dependency is updated in upstream dependencies so we do not need this constraint anymore. This will also prevent dependabot from attempting to upgrade to v4 which breaks tests. I ran a test scan via sourceclear and the related CVE this constraint was mitigating is no longer detected.