### PR TITLE
[CORE-69] Move automatic dependency updates to CORE from Workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,9 @@ updates:
       timezone: "America/New_York"
     target-branch: "master"
     reviewers:
-      - "@DataBiosphere/broadworkspaces"
+      - "@DataBiosphere/broad-core-services"
     labels:
       - "dependency"
       - "gradle"
     commit-message:
-      prefix: "[WOR-1448]"
+      prefix: "[CORE-69]"


### PR DESCRIPTION
Dependabot automatically tags an associated ticket and the workspaces team. The ticket was moved from WS to CORE; this PR updates the ticket and which team is tagged on dependabot updates.