### PR TITLE
CORE-3: upgrade to Postgres 16.3 for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:12.3
+        image: postgres:16.3
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/local-dev/local-postgres-init.sql
+++ b/local-dev/local-postgres-init.sql
@@ -3,5 +3,8 @@ CREATE DATABASE testdb_stairway;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
 CREATE ROLE dbuser_stairway WITH LOGIN ENCRYPTED PASSWORD 'dbpwd_stairway';
 
-ALTER DATABASE testdb OWNER TO dbuser;
-ALTER DATABASE testdb_stairway OWNER TO dbuser_stairway;
+GRANT USAGE ON SCHEMA testdb.public TO dbuser;
+GRANT CREATE ON SCHEMA testdb.public TO dbuser;
+
+GRANT USAGE ON SCHEMA testdb_stairway.public TO dbuser_stairway;
+GRANT CREATE ON SCHEMA testdb_stairway.public TO dbuser_stairway;

--- a/local-dev/local-postgres-init.sql
+++ b/local-dev/local-postgres-init.sql
@@ -1,10 +1,5 @@
-CREATE DATABASE testdb;
-CREATE DATABASE testdb_stairway;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
 CREATE ROLE dbuser_stairway WITH LOGIN ENCRYPTED PASSWORD 'dbpwd_stairway';
 
-GRANT USAGE ON SCHEMA "testdb.public" TO dbuser;
-GRANT CREATE ON SCHEMA "testdb.public" TO dbuser;
-
-GRANT USAGE ON SCHEMA "testdb_stairway.public" TO dbuser_stairway;
-GRANT CREATE ON SCHEMA "testdb_stairway.public" TO dbuser_stairway;
+CREATE DATABASE testdb OWNER dbuser;
+CREATE DATABASE testdb_stairway OWNER dbuser_stairway;

--- a/local-dev/local-postgres-init.sql
+++ b/local-dev/local-postgres-init.sql
@@ -3,8 +3,8 @@ CREATE DATABASE testdb_stairway;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
 CREATE ROLE dbuser_stairway WITH LOGIN ENCRYPTED PASSWORD 'dbpwd_stairway';
 
-GRANT USAGE ON SCHEMA testdb.public TO dbuser;
-GRANT CREATE ON SCHEMA testdb.public TO dbuser;
+GRANT USAGE ON SCHEMA "testdb.public" TO dbuser;
+GRANT CREATE ON SCHEMA "testdb.public" TO dbuser;
 
-GRANT USAGE ON SCHEMA testdb_stairway.public TO dbuser_stairway;
-GRANT CREATE ON SCHEMA testdb_stairway.public TO dbuser_stairway;
+GRANT USAGE ON SCHEMA "testdb_stairway.public" TO dbuser_stairway;
+GRANT CREATE ON SCHEMA "testdb_stairway.public" TO dbuser_stairway;

--- a/local-dev/local-postgres-init.sql
+++ b/local-dev/local-postgres-init.sql
@@ -3,5 +3,5 @@ CREATE DATABASE testdb_stairway;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
 CREATE ROLE dbuser_stairway WITH LOGIN ENCRYPTED PASSWORD 'dbpwd_stairway';
 
-ALTER DATABASE testdb OWNER TO 'dbuser';
-ALTER DATABASE testdb_stairway OWNER TO 'dbuser_stairway';
+ALTER DATABASE testdb OWNER TO dbuser;
+ALTER DATABASE testdb_stairway OWNER TO dbuser_stairway;

--- a/local-dev/local-postgres-init.sql
+++ b/local-dev/local-postgres-init.sql
@@ -2,3 +2,6 @@ CREATE DATABASE testdb;
 CREATE DATABASE testdb_stairway;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
 CREATE ROLE dbuser_stairway WITH LOGIN ENCRYPTED PASSWORD 'dbpwd_stairway';
+
+ALTER DATABASE testdb OWNER TO 'dbuser';
+ALTER DATABASE testdb_stairway OWNER TO 'dbuser_stairway';


### PR DESCRIPTION
For unit tests, and unit tests only, upgrade to Postgres 16.3.

16.3 is the version supported by Google: https://cloud.google.com/sql/docs/postgres/db-versions

This change allows us to get some burn-in on Postgres 16 before upgrading any live environments.

_reviewer: the Codacy failures on this PR sure look like false positives to me._