### PR TITLE
CORE-118: update jib; surface jib errors

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -27,13 +27,13 @@ jobs:
           # build sources and store the plain log without colors
           ./gradlew jibDockerBuild --console=plain \
             | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log
-          # capture exit code of jib build; piping it through perl and tee
-          # will hide any failures
+          # capture exit code of jib build; because it is piped through perl and tee,
+          # any build failures would be otherwise hidden
           jib_code=${PIPESTATUS[0]}
           # export image name from the log
           image=$(grep 'Built image' build.log | awk '{print $NF}')
           echo image="${image}" >> $GITHUB_OUTPUT
-          # exit this step with the original exit code from jib
+          # fail this step if the jib build failed
           exit $jib_code
       # scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -27,9 +27,14 @@ jobs:
           # build sources and store the plain log without colors
           ./gradlew jibDockerBuild --console=plain \
             | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log
+          # capture exit code of jib build; piping it through perl and tee
+          # will hide any failures
+          jib_code=${PIPESTATUS[0]}
           # export image name from the log
           image=$(grep 'Built image' build.log | awk '{print $NF}')
           echo image="${image}" >> $GITHUB_OUTPUT
+          # exit this step with the original exit code from jib
+          exit $jib_code
       # scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     ext {
         springBootVersion = '3.3.5'
     }
+//    dependencies {
+//        classpath group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
+//    }
 }
 
 plugins {
@@ -12,7 +15,7 @@ plugins {
 
     id 'com.diffplug.spotless' version '6.25.0'
     id 'com.github.ben-manes.versions' version '0.51.0'
-    id 'com.google.cloud.tools.jib' version '3.4.1'
+    id 'com.google.cloud.tools.jib' version '3.4.4'
     id 'de.undercouch.download' version '5.6.0'
     id 'org.hidetake.swagger.generator' version '2.19.2'
     id 'org.sonarqube' version '5.1.0.4882'
@@ -103,6 +106,9 @@ dependencies {
     annotationProcessor group: 'com.google.auto.value', name: 'auto-value', version: '1.11.0'
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: "${springBootVersion}"
 
+
+
+
     // Transitive dependency constraints due to security vulnurabilities in prior versions.
     // These are not directly included, they are just constrained if they are pulled in as
     // transitive dependencies.
@@ -111,8 +117,11 @@ dependencies {
         implementation('com.nimbusds:nimbus-jose-jwt:9.42')
         implementation('io.projectreactor.netty:reactor-netty-http:1.1.23')
         implementation('com.fasterxml.jackson:jackson-bom:2.18.0')
+
     }
 }
+
+
 
 // for scans
 if (hasProperty('buildScan')) {

--- a/build.gradle
+++ b/build.gradle
@@ -108,9 +108,6 @@ dependencies {
     annotationProcessor group: 'com.google.auto.value', name: 'auto-value', version: '1.11.0'
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: "${springBootVersion}"
 
-
-
-
     // Transitive dependency constraints due to security vulnurabilities in prior versions.
     // These are not directly included, they are just constrained if they are pulled in as
     // transitive dependencies.
@@ -119,11 +116,8 @@ dependencies {
         implementation('com.nimbusds:nimbus-jose-jwt:9.42')
         implementation('io.projectreactor.netty:reactor-netty-http:1.1.23')
         implementation('com.fasterxml.jackson:jackson-bom:2.18.0')
-
     }
 }
-
-
 
 // for scans
 if (hasProperty('buildScan')) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,11 @@ buildscript {
     ext {
         springBootVersion = '3.3.5'
     }
-//    dependencies {
-//        classpath group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
-//    }
+    dependencies {
+        // jib build requires this dependency;
+        // see https://github.com/GoogleContainerTools/jib/issues/4235
+        classpath group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
+    }
 }
 
 plugins {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-118 states that upgrading the `jib` version causes our Trivy scan to fail.

What was actually happening is that upgrading `jib` caused the jib build to fail. The jib failure did not throw an error in GitHub Actions. The workflow continued on to attempt the Trivy scan, but since jib failed there was no docker image to scan, so Trivy threw an error. A previous PR illustrates that behavior here: https://github.com/DataBiosphere/terra-resource-buffer/actions/runs/11502274753/job/32016865400?pr=364

This PR contains the following changes:
1. In 48b1e491ffbbec569971d9e3fc9d65c800dfb316, update the GHA such that if jib fails to build a docker image, the GHA workflow fails at that point. You can look at the workflows run on that specific commit and see the more helpful error: https://github.com/DataBiosphere/terra-resource-buffer/actions/runs/11653405652/job/32445737249
2. Update jib to latest version, and update our Gradle `buildscript` to give jib the dependency it needs to avoid error. This issue is discussed in https://github.com/GoogleContainerTools/jib/issues/4235 and the workaround in this PR is based on comments in that issue. We previously ran into this issue at https://github.com/DataBiosphere/terra-resource-buffer/pull/324 but did not resolve the problem at that time.