### PR TITLE
[DDO-3972] Stop sending perf test notifications to #dsde-qa

### DIFF
--- a/.github/workflows/test-runner-nightly-perf.yml
+++ b/.github/workflows/test-runner-nightly-perf.yml
@@ -52,19 +52,6 @@ jobs:
         with:
           name: Test Reports
           path: buffer-clienttests/build/reports
-      - name: Notify QA Slack
-        #  Always notify #dsde-qa when test finishes, and it is not manually triggered(workflow_dispatch).
-        if: github.event_name != 'workflow_dispatch' && always()
-        uses: broadinstitute/action-slack@v3.8.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#dsde-qa"
-          username: "Resource Buffer tests"
-          text: "Perf tests"
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
       - name: Notify PF team when perf test fails
         if: failure() && github.event_name != 'workflow_dispatch'
         uses: broadinstitute/action-slack@v3.8.0


### PR DESCRIPTION
It looks like a recent PR (#398) had the side effect of reenabling Buffer's nightly perf tests, but they no longer work. I'd like to remove notifications to the #dsde-qa channel since it is used for monolith release triage and these are not release-blocking. Notifications will continue to go to other configured Slack channels.