### PR TITLE
CORE-246 Upgrading to cache v4 

### DIFF
--- a/.github/workflows/test-runner-nightly-perf.yml
+++ b/.github/workflows/test-runner-nightly-perf.yml
@@ -34,7 +34,7 @@ jobs:
           buffer-clienttests/tools/render-config.sh buffertest ${{ steps.vault-token-step.outputs.vault-token }}
           buffer-clienttests/tools/render-config.sh yyu ${{ steps.vault-token-step.outputs.vault-token }}
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .gradle/caches


### PR DESCRIPTION
The cache backend service has been rewritten from the ground up for improved performance and reliability. [actions/cache](https://github.com/actions/cache) now integrates with the new cache service (v2) APIs.

The new service will gradually roll out as of February 1st, 2025. The legacy service will also be sunset on the same date. Changes in these release are fully backward compatible.

More info here: https://github.com/marketplace/actions/cache