### PR TITLE
DT-1342: Increase (revert back) TDR tools pool size from 1000 to 2000

### DIFF
--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -6,7 +6,7 @@ poolConfigs:
     size: 200
     resourceConfigName: "cwb_ws_resource_quality_v11"
   - poolId: "datarepo_v1"
-    size: 1000
+    size: 2000
     resourceConfigName: "datarepo_v1"
   - poolId: "vpc_sc_qa-fiab_v6"
     size: 100


### PR DESCRIPTION
Increase the datarepo tools pool size to prevent tests from blocking or failing unnecessarily.

This value was changed from 1500 to 2000: https://github.com/DataBiosphere/terra-resource-buffer/pull/293
And then was changed from 2000 to 1000: https://github.com/DataBiosphere/terra-resource-buffer/pull/374

The usage of this pool depends heavily on how much work is being done on TDR. If there are more than three developers creating one or two branches each, a pool size of 1000 can be exhausted due to concurrent test execution. In addition to more activity, recent changes to allow integration tests to run in parallel, and to avoid needing to "lock" an integration host to run tests on, may have put a greater burden on this resource.

Here's the pool usage graph of the last 7 days
![image](https://github.com/user-attachments/assets/586194ec-89ee-4271-a215-84cb013c9ba6)

The exhaustion spike occurred yesterday, and the capacity dipped down to 15% last week as well, so this usage doesn't seem atypical. Graphana's data only goes back 10 days so there's no way to easily see long term trends.