### PR TITLE
CORE-376: turn off double-tracing and 'failed to export spans' error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ repositories {
 
 dependencies {
     // Terra deps - we get Stairway via TCL
-    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.38-SNAPSHOT'
+    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.39-SNAPSHOT'
     implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.34-SNAPSHOT'
     implementation group: 'bio.terra', name: 'terra-resource-janitor-client', version: '0.113.44-SNAPSHOT'
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-376

Update TCL to get its fix for the "failed to export spans" error.

See https://github.com/DataBiosphere/terra-common-lib/pull/229