### PR TITLE
CORE-385: exclude azure libs from CRL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,10 @@ repositories {
 dependencies {
     // Terra deps - we get Stairway via TCL
     implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.39-SNAPSHOT'
-    implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.34-SNAPSHOT'
+    implementation (group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.34-SNAPSHOT') {
+        exclude(group: 'com.microsoft.azure')
+        exclude(group: 'com.azure')
+    }
     implementation group: 'bio.terra', name: 'terra-resource-janitor-client', version: '0.113.49-SNAPSHOT'
 
     // Versioned direct deps


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-385 is a security finding on `json-smart`.

`json-smart` is pulled in by `com.azure:azure-identity`, which is pulled in by `bio.terra:terra-cloud-resource-lib`. However, RBS doesn't need those Azure libs.

This PR excludes the Azure libs from CRL, which in turn excludes `json-smart`.

Part of a group of PRs:
* https://github.com/broadinstitute/rawls/pull/3240
* https://github.com/DataBiosphere/terra-resource-buffer/pull/422
* https://github.com/broadinstitute/thurloe/pull/377

