### PR TITLE
CORE-69: dependabot tweaks

### DIFF
--- a/buffer-clienttests/build.gradle
+++ b/buffer-clienttests/build.gradle
@@ -25,7 +25,7 @@ dependencies {
         slf4j = "2.0.17"
         hamcrest = "3.0"
 
-        googleOauth2 = "1.33.1"
+        googleOauth2 = "1.36.0"
 
         bufferServiceClient = "0.4.3-SNAPSHOT"
         testRunner = "0.2.1-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Build Script Classpath
 buildscript {
     ext {
-        springBootVersion = '3.4.5'
+        springBootVersion = '3.5.0'
     }
     dependencies {
         // jib build requires this dependency;
@@ -16,12 +16,12 @@ plugins {
     id 'jacoco'
     id 'java'
 
-    id 'com.diffplug.spotless' version '7.0.3'
+    id 'com.diffplug.spotless' version '7.0.4'
     id 'com.github.ben-manes.versions' version '0.52.0'
     id 'com.google.cloud.tools.jib' version '3.4.5'
     id 'de.undercouch.download' version '5.6.0'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id 'org.sonarqube' version '6.1.0.5360'
+    id 'org.sonarqube' version '6.2.0.5505'
     id 'org.springframework.boot' version "${springBootVersion}"
     id 'com.srcclr.gradle' version '3.1.12'
 }
@@ -65,7 +65,7 @@ repositories {
 
 dependencies {
     // Terra deps - we get Stairway via TCL
-    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.40-SNAPSHOT'
+    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.42-SNAPSHOT'
     implementation (group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.34-SNAPSHOT') {
         exclude(group: 'com.microsoft.azure')
         exclude(group: 'com.azure')
@@ -73,18 +73,18 @@ dependencies {
     implementation group: 'bio.terra', name: 'terra-resource-janitor-client', version: '0.113.49-SNAPSHOT'
 
     // Versioned direct deps
-    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '6.5.0'
-    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '6.5.0'
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '6.8.0'
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '6.8.0'
     implementation group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.11.0'
-    implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.139.1'
+    implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.139.4'
     implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
     implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.1.1'
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.31.1'
+    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.32.0'
     implementation group: 'org.webjars', name: 'webjars-locator-core', version: '0.59'
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
-    var gcpOpenTelemetryExporterVersion = '0.34.0'
+    var gcpOpenTelemetryExporterVersion = '0.35.0'
     implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 
@@ -94,13 +94,13 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-pool2', version: '2.12.1'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jdbc', version: "${springBootVersion}"
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: "${springBootVersion}"
-    implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.11'
+    implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.12'
 
     // Swagger deps
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.19.0'
-    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.15'
-    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.30'
-    runtimeOnly group: 'org.webjars.npm', name: 'swagger-ui-dist', version: '5.21.0'
+    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.16'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.32'
+    runtimeOnly group: 'org.webjars.npm', name: 'swagger-ui-dist', version: '5.22.0'
     swaggerCodegen group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli', version: '3.0.61'
 
     // Test deps
@@ -117,8 +117,8 @@ dependencies {
     // transitive dependencies.
     constraints {
         implementation('org.yaml:snakeyaml:2.4')
-        implementation('com.nimbusds:nimbus-jose-jwt:10.2')
-        implementation('io.projectreactor.netty:reactor-netty-http:1.2.5')
+        implementation('com.nimbusds:nimbus-jose-jwt:10.3')
+        implementation('io.projectreactor.netty:reactor-netty-http:1.2.6')
         implementation('com.fasterxml.jackson:jackson-bom:2.19.0')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Build Script Classpath
 buildscript {
     ext {
-        springBootVersion = '3.5.0'
+        springBootVersion = '3.4.5'
     }
     dependencies {
         // jib build requires this dependency;

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ repositories {
 
 dependencies {
     // Terra deps - we get Stairway via TCL
-    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.42-SNAPSHOT'
+    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.40-SNAPSHOT'
     implementation (group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.34-SNAPSHOT') {
         exclude(group: 'com.microsoft.azure')
         exclude(group: 'com.azure')

--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ dependencies {
     implementation group: 'bio.terra', name: 'terra-resource-janitor-client', version: '0.113.49-SNAPSHOT'
 
     // Versioned direct deps
-    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '6.8.0'
-    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '6.8.0'
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '6.5.0'
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '6.5.0'
     implementation group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.11.0'
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.139.4'
     implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.139.4'
     implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
     implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.1.1'
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.32.0'
+    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.31.1'
     implementation group: 'org.webjars', name: 'webjars-locator-core', version: '0.59'
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 

--- a/terra-resource-buffer-client/build.gradle
+++ b/terra-resource-buffer-client/build.gradle
@@ -14,8 +14,8 @@ repositories {
 
 dependencies {
     swaggerCodegen group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli', version: '3.0.61'
-    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.30'
-    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.15'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.32'
+    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.16'
     implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '3.1.10'
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '3.1.10'
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '3.1.10'


### PR DESCRIPTION
This is a copy of Dependabot PR #427, minus the Spring Boot 3.4.5->3.5.0 upgrade. Let's see how this does on integration tests.