### PR TITLE
CORE-536: dependabot no otel

### DIFF
--- a/buffer-clienttests/build.gradle
+++ b/buffer-clienttests/build.gradle
@@ -25,7 +25,7 @@ dependencies {
         slf4j = "2.0.17"
         hamcrest = "3.0"
 
-        googleOauth2 = "1.33.1"
+        googleOauth2 = "1.36.0"
 
         bufferServiceClient = "0.4.3-SNAPSHOT"
         testRunner = "0.2.1-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Build Script Classpath
 buildscript {
     ext {
-        springBootVersion = '3.4.5'
+        springBootVersion = '3.5.0'
     }
     dependencies {
         // jib build requires this dependency;
@@ -16,12 +16,12 @@ plugins {
     id 'jacoco'
     id 'java'
 
-    id 'com.diffplug.spotless' version '7.0.3'
+    id 'com.diffplug.spotless' version '7.0.4'
     id 'com.github.ben-manes.versions' version '0.52.0'
     id 'com.google.cloud.tools.jib' version '3.4.5'
     id 'de.undercouch.download' version '5.6.0'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id 'org.sonarqube' version '6.1.0.5360'
+    id 'org.sonarqube' version '6.2.0.5505'
     id 'org.springframework.boot' version "${springBootVersion}"
     id 'com.srcclr.gradle' version '3.1.12'
 }
@@ -65,7 +65,7 @@ repositories {
 
 dependencies {
     // Terra deps - we get Stairway via TCL
-    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.40-SNAPSHOT'
+    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.42-SNAPSHOT'
     implementation (group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.34-SNAPSHOT') {
         exclude(group: 'com.microsoft.azure')
         exclude(group: 'com.azure')
@@ -73,18 +73,18 @@ dependencies {
     implementation group: 'bio.terra', name: 'terra-resource-janitor-client', version: '0.113.49-SNAPSHOT'
 
     // Versioned direct deps
-    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '6.5.0'
-    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '6.5.0'
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '6.8.0'
+    implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '6.8.0'
     implementation group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.11.0'
-    implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.139.1'
+    implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.139.4'
     implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
     implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.1.1'
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.31.1'
+    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.32.0'
     implementation group: 'org.webjars', name: 'webjars-locator-core', version: '0.59'
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
-    var gcpOpenTelemetryExporterVersion = '0.34.0'
+    var gcpOpenTelemetryExporterVersion = '0.35.0'
     implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 
@@ -94,13 +94,13 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-pool2', version: '2.12.1'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jdbc', version: "${springBootVersion}"
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: "${springBootVersion}"
-    implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.11'
+    implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.12'
 
     // Swagger deps
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.19.0'
-    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.15'
-    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.30'
-    runtimeOnly group: 'org.webjars.npm', name: 'swagger-ui-dist', version: '5.21.0'
+    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.16'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.32'
+    runtimeOnly group: 'org.webjars.npm', name: 'swagger-ui-dist', version: '5.22.0'
     swaggerCodegen group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli', version: '3.0.61'
 
     // Test deps
@@ -117,8 +117,8 @@ dependencies {
     // transitive dependencies.
     constraints {
         implementation('org.yaml:snakeyaml:2.4')
-        implementation('com.nimbusds:nimbus-jose-jwt:10.2')
-        implementation('io.projectreactor.netty:reactor-netty-http:1.2.5')
+        implementation('com.nimbusds:nimbus-jose-jwt:10.3')
+        implementation('io.projectreactor.netty:reactor-netty-http:1.2.6')
         implementation('com.fasterxml.jackson:jackson-bom:2.19.0')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
-    var gcpOpenTelemetryExporterVersion = '0.35.0'
+    var gcpOpenTelemetryExporterVersion = '0.34.0'
     implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 

--- a/terra-resource-buffer-client/build.gradle
+++ b/terra-resource-buffer-client/build.gradle
@@ -14,8 +14,8 @@ repositories {
 
 dependencies {
     swaggerCodegen group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli', version: '3.0.61'
-    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.30'
-    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.15'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.32'
+    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.16'
     implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '3.1.10'
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '3.1.10'
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '3.1.10'


### PR DESCRIPTION
This is a copy of Dependabot PR #427, minus the com.google.cloud.opentelemetry:exporter-* 0.34->0.35 bump. You can review each commit to see exactly what I did.

description copied (with otel removed) from #427:

---

Bumps the minor-patch-dependencies group with 21 updates:

| Package | From | To |
| --- | --- | --- |
| [org.springframework.boot:spring-boot-starter-test](https://github.com/spring-projects/spring-boot) | `3.4.5` | `3.5.0` |
| [org.springframework.boot:spring-boot-starter-data-jdbc](https://github.com/spring-projects/spring-boot) | `3.4.5` | `3.5.0` |
| [org.springframework.boot:spring-boot-starter-web](https://github.com/spring-projects/spring-boot) | `3.4.5` | `3.5.0` |
| [org.springframework.boot:spring-boot-configuration-processor](https://github.com/spring-projects/spring-boot) | `3.4.5` | `3.5.0` |
| [org.springframework.boot](https://github.com/spring-projects/spring-boot) | `3.4.5` | `3.5.0` |
| [com.nimbusds:nimbus-jose-jwt](https://bitbucket.org/connect2id/nimbus-jose-jwt) | `10.2` | `10.3` |
| [io.projectreactor.netty:reactor-netty-http](https://github.com/reactor/reactor-netty) | `1.2.5` | `1.2.6` |
| bio.terra:terra-common-lib | `1.1.40-SNAPSHOT` | `1.1.42-SNAPSHOT` |
| [net.javacrumbs.shedlock:shedlock-spring](https://github.com/lukas-krecan/ShedLock) | `6.5.0` | `6.8.0` |
| net.javacrumbs.shedlock:shedlock-provider-jdbc-template | `6.5.0` | `6.8.0` |
| [com.google.cloud:google-cloud-pubsub](https://github.com/googleapis/java-pubsub) | `1.139.1` | `1.139.4` |
| [org.liquibase:liquibase-core](https://github.com/liquibase/liquibase) | `4.31.1` | `4.32.0` |
| [org.springframework.retry:spring-retry](https://github.com/spring-projects/spring-retry) | `2.0.11` | `2.0.12` |
| io.swagger:swagger-annotations | `1.6.15` | `1.6.16` |
| io.swagger.core.v3:swagger-annotations | `2.2.30` | `2.2.32` |
| [org.webjars.npm:swagger-ui-dist](https://github.com/swagger-api/swagger-ui) | `5.21.0` | `5.22.0` |
| com.diffplug.spotless | `7.0.3` | `7.0.4` |
| org.sonarqube | `6.1.0.5360` | `6.2.0.5505` |
| com.google.auth:google-auth-library-oauth2-http | `1.33.1` | `1.36.0` |


Updates `org.springframework.boot:spring-boot-starter-test` from 3.4.5 to 3.5.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-test's releases</a>.</em></p>
<blockquote>
<h2>v3.5.0</h2>
<p>Full <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes">release notes for Spring Boot 3.5</a> are available on the wiki.</p>
<h2>:star: New Features</h2>
<ul>
<li>Make heapdump endpoint restricted by default <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45624">#45624</a></li>
<li>Remove SSL status tag from metrics <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45602">#45602</a></li>
<li>Remove 'spring.http.client' deprecation and change 'spring.http.reactiveclient.settings' to 'spring.http.reactiveclient' <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45507">#45507</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Unable to override/set nested ConfigurationProperties by passing as a system property <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45639">#45639</a></li>
<li>ValidationAutoConfiguration triggers early initialization of properties binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45618">#45618</a></li>
<li>Micrometer &quot;enable&quot; annotations property does not cover observed aspect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45617">#45617</a></li>
<li>spring.graphql.sse.timeout is no longer exposed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45613">#45613</a></li>
<li>SpringApplication.setEnvironmentPrefix is ignored when reading SPRING_PROFILES_ACTIVE <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45549">#45549</a></li>
<li>IllegalStateException when extracting using layers a module with no code of its own <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45449">#45449</a></li>
<li>Removed spring.batch.initialize-schema property is still considered <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45380">#45380</a></li>
<li>ReactorHttpClientBuilder does not offer a factory method to create the HttpClient <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45378">#45378</a></li>
<li>Suggested values for spring.jpa.hibernate.ddl-auto are not aligned with Hibernate <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45351">#45351</a></li>
<li>Custom default units declared on a field are ignored when binding properties in a native image <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45347">#45347</a></li>
<li>DockerRegistryConfigAuthentication uses the wrong serverUrl as a fallback for the Credentials helper <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45345">#45345</a></li>
<li>Various spring.datasource properties are mistakenly marked as ignored <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45342">#45342</a></li>
<li>JerseyWebApplicationInitializer always gets loaded, setting a ServletContext initParameter <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45297">#45297</a></li>
<li>DockerRegistryConfigAuthentication does not align with Docker CLI <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45292">#45292</a></li>
<li>Unlike the Docker CLI, &quot;\x00&quot; characters are not trimmed from a decoded Docker Registry password <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45290">#45290</a></li>
<li>CloudFoundry security matcher logs a warning due to use of the 'ignoring()' method <a href="https://redirect.github.com/spring-projects/spring-boot/issues/32622">#32622</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Document the java info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45634">#45634</a></li>
<li>Document the process info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45632">#45632</a></li>
<li>Document the os info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45630">#45630</a></li>
<li>Document typical spring.application.group and name use <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45628">#45628</a></li>
<li>Document that bean methods should be static when annotated with <code>@ConfigurationPropertiesBinding</code> <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45626">#45626</a></li>
<li>Document the way that primary Kotlin constructors are used when binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45553">#45553</a></li>
<li>Improve &quot;profile&quot; reference documentation with additional admonitions  <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45551">#45551</a></li>
<li>Improve setEnvironmentPrefix(...) reference documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45376">#45376</a></li>
<li>Document all the available Testcontainers integrations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45367">#45367</a></li>
<li>Document when a spring.config.import value is relative and when it is fixed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45363">#45363</a></li>
<li>Update org.cyclonedx.bom version in docs to 2.3.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45320">#45320</a></li>
<li>Update link to &quot;Parameter Name Retention&quot; section of Spring Framework's release notes <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45299">#45299</a></li>
</ul>
<h2>:hammer: Dependency Upgrades</h2>
<ul>
<li>Prevent upgrade to Prometheus Client 1.3.7 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45541">#45541</a></li>
<li>Upgrade to Couchbase Client 3.8.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45539">#45539</a></li>
<li>Upgrade to Elasticsearch 8.18.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45447">#45447</a></li>
<li>Upgrade to GraphQL Java 24.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45588">#45588</a></li>
<li>Upgrade to Hibernate 6.6.15.Final <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45540">#45540</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/8c2d6453243f319accaef7a190ff8ddf89f482a2"><code>8c2d645</code></a> Release v3.5.0</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/0b49e78c21f5afaf2db23bea2a1f8b369b3d92a7"><code>0b49e78</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c684fa4050d89a505f28257fef5462745671b6e5"><code>c684fa4</code></a> Switch <code>make-default</code> for publish-to-sdkman to 3.5.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/569519285046967a85f20cefe4200fcfc35a21c8"><code>5695192</code></a> Ensure descendants are always recalculated on cache refresh</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/31f549efc699e8f2f597ddf08bb572ad9a74b358"><code>31f549e</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/68df6f594167d760e67dd97eed0783e3f3a5fafd"><code>68df6f5</code></a> Next development version (v3.4.7-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/9f46877c7ea17452f1f744281aa0008fadcc82f9"><code>9f46877</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/404a0df5e8cffad3c9cbc896b0382347586102bf"><code>404a0df</code></a> Merge branch '3.3.x' into 3.4.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/e331846302f763905e9e0d3cf96438f60c7bd3c4"><code>e331846</code></a> Next development version (v3.3.13-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/b142798bdb8dde5d8a6ab01e70d6d78c1a6752c7"><code>b142798</code></a> Merge branch '3.4.x'</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v3.4.5...v3.5.0">compare view</a></li>
</ul>
</details>
<br />

Updates `org.springframework.boot:spring-boot-starter-data-jdbc` from 3.4.5 to 3.5.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-data-jdbc's releases</a>.</em></p>
<blockquote>
<h2>v3.5.0</h2>
<p>Full <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes">release notes for Spring Boot 3.5</a> are available on the wiki.</p>
<h2>:star: New Features</h2>
<ul>
<li>Make heapdump endpoint restricted by default <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45624">#45624</a></li>
<li>Remove SSL status tag from metrics <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45602">#45602</a></li>
<li>Remove 'spring.http.client' deprecation and change 'spring.http.reactiveclient.settings' to 'spring.http.reactiveclient' <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45507">#45507</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Unable to override/set nested ConfigurationProperties by passing as a system property <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45639">#45639</a></li>
<li>ValidationAutoConfiguration triggers early initialization of properties binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45618">#45618</a></li>
<li>Micrometer &quot;enable&quot; annotations property does not cover observed aspect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45617">#45617</a></li>
<li>spring.graphql.sse.timeout is no longer exposed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45613">#45613</a></li>
<li>SpringApplication.setEnvironmentPrefix is ignored when reading SPRING_PROFILES_ACTIVE <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45549">#45549</a></li>
<li>IllegalStateException when extracting using layers a module with no code of its own <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45449">#45449</a></li>
<li>Removed spring.batch.initialize-schema property is still considered <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45380">#45380</a></li>
<li>ReactorHttpClientBuilder does not offer a factory method to create the HttpClient <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45378">#45378</a></li>
<li>Suggested values for spring.jpa.hibernate.ddl-auto are not aligned with Hibernate <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45351">#45351</a></li>
<li>Custom default units declared on a field are ignored when binding properties in a native image <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45347">#45347</a></li>
<li>DockerRegistryConfigAuthentication uses the wrong serverUrl as a fallback for the Credentials helper <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45345">#45345</a></li>
<li>Various spring.datasource properties are mistakenly marked as ignored <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45342">#45342</a></li>
<li>JerseyWebApplicationInitializer always gets loaded, setting a ServletContext initParameter <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45297">#45297</a></li>
<li>DockerRegistryConfigAuthentication does not align with Docker CLI <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45292">#45292</a></li>
<li>Unlike the Docker CLI, &quot;\x00&quot; characters are not trimmed from a decoded Docker Registry password <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45290">#45290</a></li>
<li>CloudFoundry security matcher logs a warning due to use of the 'ignoring()' method <a href="https://redirect.github.com/spring-projects/spring-boot/issues/32622">#32622</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Document the java info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45634">#45634</a></li>
<li>Document the process info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45632">#45632</a></li>
<li>Document the os info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45630">#45630</a></li>
<li>Document typical spring.application.group and name use <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45628">#45628</a></li>
<li>Document that bean methods should be static when annotated with <code>@ConfigurationPropertiesBinding</code> <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45626">#45626</a></li>
<li>Document the way that primary Kotlin constructors are used when binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45553">#45553</a></li>
<li>Improve &quot;profile&quot; reference documentation with additional admonitions  <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45551">#45551</a></li>
<li>Improve setEnvironmentPrefix(...) reference documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45376">#45376</a></li>
<li>Document all the available Testcontainers integrations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45367">#45367</a></li>
<li>Document when a spring.config.import value is relative and when it is fixed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45363">#45363</a></li>
<li>Update org.cyclonedx.bom version in docs to 2.3.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45320">#45320</a></li>
<li>Update link to &quot;Parameter Name Retention&quot; section of Spring Framework's release notes <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45299">#45299</a></li>
</ul>
<h2>:hammer: Dependency Upgrades</h2>
<ul>
<li>Prevent upgrade to Prometheus Client 1.3.7 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45541">#45541</a></li>
<li>Upgrade to Couchbase Client 3.8.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45539">#45539</a></li>
<li>Upgrade to Elasticsearch 8.18.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45447">#45447</a></li>
<li>Upgrade to GraphQL Java 24.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45588">#45588</a></li>
<li>Upgrade to Hibernate 6.6.15.Final <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45540">#45540</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/8c2d6453243f319accaef7a190ff8ddf89f482a2"><code>8c2d645</code></a> Release v3.5.0</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/0b49e78c21f5afaf2db23bea2a1f8b369b3d92a7"><code>0b49e78</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c684fa4050d89a505f28257fef5462745671b6e5"><code>c684fa4</code></a> Switch <code>make-default</code> for publish-to-sdkman to 3.5.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/569519285046967a85f20cefe4200fcfc35a21c8"><code>5695192</code></a> Ensure descendants are always recalculated on cache refresh</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/31f549efc699e8f2f597ddf08bb572ad9a74b358"><code>31f549e</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/68df6f594167d760e67dd97eed0783e3f3a5fafd"><code>68df6f5</code></a> Next development version (v3.4.7-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/9f46877c7ea17452f1f744281aa0008fadcc82f9"><code>9f46877</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/404a0df5e8cffad3c9cbc896b0382347586102bf"><code>404a0df</code></a> Merge branch '3.3.x' into 3.4.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/e331846302f763905e9e0d3cf96438f60c7bd3c4"><code>e331846</code></a> Next development version (v3.3.13-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/b142798bdb8dde5d8a6ab01e70d6d78c1a6752c7"><code>b142798</code></a> Merge branch '3.4.x'</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v3.4.5...v3.5.0">compare view</a></li>
</ul>
</details>
<br />

Updates `org.springframework.boot:spring-boot-starter-web` from 3.4.5 to 3.5.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-web's releases</a>.</em></p>
<blockquote>
<h2>v3.5.0</h2>
<p>Full <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes">release notes for Spring Boot 3.5</a> are available on the wiki.</p>
<h2>:star: New Features</h2>
<ul>
<li>Make heapdump endpoint restricted by default <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45624">#45624</a></li>
<li>Remove SSL status tag from metrics <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45602">#45602</a></li>
<li>Remove 'spring.http.client' deprecation and change 'spring.http.reactiveclient.settings' to 'spring.http.reactiveclient' <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45507">#45507</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Unable to override/set nested ConfigurationProperties by passing as a system property <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45639">#45639</a></li>
<li>ValidationAutoConfiguration triggers early initialization of properties binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45618">#45618</a></li>
<li>Micrometer &quot;enable&quot; annotations property does not cover observed aspect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45617">#45617</a></li>
<li>spring.graphql.sse.timeout is no longer exposed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45613">#45613</a></li>
<li>SpringApplication.setEnvironmentPrefix is ignored when reading SPRING_PROFILES_ACTIVE <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45549">#45549</a></li>
<li>IllegalStateException when extracting using layers a module with no code of its own <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45449">#45449</a></li>
<li>Removed spring.batch.initialize-schema property is still considered <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45380">#45380</a></li>
<li>ReactorHttpClientBuilder does not offer a factory method to create the HttpClient <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45378">#45378</a></li>
<li>Suggested values for spring.jpa.hibernate.ddl-auto are not aligned with Hibernate <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45351">#45351</a></li>
<li>Custom default units declared on a field are ignored when binding properties in a native image <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45347">#45347</a></li>
<li>DockerRegistryConfigAuthentication uses the wrong serverUrl as a fallback for the Credentials helper <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45345">#45345</a></li>
<li>Various spring.datasource properties are mistakenly marked as ignored <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45342">#45342</a></li>
<li>JerseyWebApplicationInitializer always gets loaded, setting a ServletContext initParameter <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45297">#45297</a></li>
<li>DockerRegistryConfigAuthentication does not align with Docker CLI <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45292">#45292</a></li>
<li>Unlike the Docker CLI, &quot;\x00&quot; characters are not trimmed from a decoded Docker Registry password <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45290">#45290</a></li>
<li>CloudFoundry security matcher logs a warning due to use of the 'ignoring()' method <a href="https://redirect.github.com/spring-projects/spring-boot/issues/32622">#32622</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Document the java info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45634">#45634</a></li>
<li>Document the process info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45632">#45632</a></li>
<li>Document the os info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45630">#45630</a></li>
<li>Document typical spring.application.group and name use <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45628">#45628</a></li>
<li>Document that bean methods should be static when annotated with <code>@ConfigurationPropertiesBinding</code> <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45626">#45626</a></li>
<li>Document the way that primary Kotlin constructors are used when binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45553">#45553</a></li>
<li>Improve &quot;profile&quot; reference documentation with additional admonitions  <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45551">#45551</a></li>
<li>Improve setEnvironmentPrefix(...) reference documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45376">#45376</a></li>
<li>Document all the available Testcontainers integrations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45367">#45367</a></li>
<li>Document when a spring.config.import value is relative and when it is fixed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45363">#45363</a></li>
<li>Update org.cyclonedx.bom version in docs to 2.3.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45320">#45320</a></li>
<li>Update link to &quot;Parameter Name Retention&quot; section of Spring Framework's release notes <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45299">#45299</a></li>
</ul>
<h2>:hammer: Dependency Upgrades</h2>
<ul>
<li>Prevent upgrade to Prometheus Client 1.3.7 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45541">#45541</a></li>
<li>Upgrade to Couchbase Client 3.8.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45539">#45539</a></li>
<li>Upgrade to Elasticsearch 8.18.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45447">#45447</a></li>
<li>Upgrade to GraphQL Java 24.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45588">#45588</a></li>
<li>Upgrade to Hibernate 6.6.15.Final <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45540">#45540</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/8c2d6453243f319accaef7a190ff8ddf89f482a2"><code>8c2d645</code></a> Release v3.5.0</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/0b49e78c21f5afaf2db23bea2a1f8b369b3d92a7"><code>0b49e78</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c684fa4050d89a505f28257fef5462745671b6e5"><code>c684fa4</code></a> Switch <code>make-default</code> for publish-to-sdkman to 3.5.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/569519285046967a85f20cefe4200fcfc35a21c8"><code>5695192</code></a> Ensure descendants are always recalculated on cache refresh</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/31f549efc699e8f2f597ddf08bb572ad9a74b358"><code>31f549e</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/68df6f594167d760e67dd97eed0783e3f3a5fafd"><code>68df6f5</code></a> Next development version (v3.4.7-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/9f46877c7ea17452f1f744281aa0008fadcc82f9"><code>9f46877</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/404a0df5e8cffad3c9cbc896b0382347586102bf"><code>404a0df</code></a> Merge branch '3.3.x' into 3.4.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/e331846302f763905e9e0d3cf96438f60c7bd3c4"><code>e331846</code></a> Next development version (v3.3.13-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/b142798bdb8dde5d8a6ab01e70d6d78c1a6752c7"><code>b142798</code></a> Merge branch '3.4.x'</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v3.4.5...v3.5.0">compare view</a></li>
</ul>
</details>
<br />

Updates `org.springframework.boot:spring-boot-configuration-processor` from 3.4.5 to 3.5.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-configuration-processor's releases</a>.</em></p>
<blockquote>
<h2>v3.5.0</h2>
<p>Full <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes">release notes for Spring Boot 3.5</a> are available on the wiki.</p>
<h2>:star: New Features</h2>
<ul>
<li>Make heapdump endpoint restricted by default <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45624">#45624</a></li>
<li>Remove SSL status tag from metrics <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45602">#45602</a></li>
<li>Remove 'spring.http.client' deprecation and change 'spring.http.reactiveclient.settings' to 'spring.http.reactiveclient' <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45507">#45507</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Unable to override/set nested ConfigurationProperties by passing as a system property <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45639">#45639</a></li>
<li>ValidationAutoConfiguration triggers early initialization of properties binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45618">#45618</a></li>
<li>Micrometer &quot;enable&quot; annotations property does not cover observed aspect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45617">#45617</a></li>
<li>spring.graphql.sse.timeout is no longer exposed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45613">#45613</a></li>
<li>SpringApplication.setEnvironmentPrefix is ignored when reading SPRING_PROFILES_ACTIVE <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45549">#45549</a></li>
<li>IllegalStateException when extracting using layers a module with no code of its own <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45449">#45449</a></li>
<li>Removed spring.batch.initialize-schema property is still considered <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45380">#45380</a></li>
<li>ReactorHttpClientBuilder does not offer a factory method to create the HttpClient <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45378">#45378</a></li>
<li>Suggested values for spring.jpa.hibernate.ddl-auto are not aligned with Hibernate <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45351">#45351</a></li>
<li>Custom default units declared on a field are ignored when binding properties in a native image <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45347">#45347</a></li>
<li>DockerRegistryConfigAuthentication uses the wrong serverUrl as a fallback for the Credentials helper <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45345">#45345</a></li>
<li>Various spring.datasource properties are mistakenly marked as ignored <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45342">#45342</a></li>
<li>JerseyWebApplicationInitializer always gets loaded, setting a ServletContext initParameter <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45297">#45297</a></li>
<li>DockerRegistryConfigAuthentication does not align with Docker CLI <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45292">#45292</a></li>
<li>Unlike the Docker CLI, &quot;\x00&quot; characters are not trimmed from a decoded Docker Registry password <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45290">#45290</a></li>
<li>CloudFoundry security matcher logs a warning due to use of the 'ignoring()' method <a href="https://redirect.github.com/spring-projects/spring-boot/issues/32622">#32622</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Document the java info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45634">#45634</a></li>
<li>Document the process info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45632">#45632</a></li>
<li>Document the os info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45630">#45630</a></li>
<li>Document typical spring.application.group and name use <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45628">#45628</a></li>
<li>Document that bean methods should be static when annotated with <code>@ConfigurationPropertiesBinding</code> <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45626">#45626</a></li>
<li>Document the way that primary Kotlin constructors are used when binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45553">#45553</a></li>
<li>Improve &quot;profile&quot; reference documentation with additional admonitions  <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45551">#45551</a></li>
<li>Improve setEnvironmentPrefix(...) reference documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45376">#45376</a></li>
<li>Document all the available Testcontainers integrations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45367">#45367</a></li>
<li>Document when a spring.config.import value is relative and when it is fixed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45363">#45363</a></li>
<li>Update org.cyclonedx.bom version in docs to 2.3.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45320">#45320</a></li>
<li>Update link to &quot;Parameter Name Retention&quot; section of Spring Framework's release notes <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45299">#45299</a></li>
</ul>
<h2>:hammer: Dependency Upgrades</h2>
<ul>
<li>Prevent upgrade to Prometheus Client 1.3.7 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45541">#45541</a></li>
<li>Upgrade to Couchbase Client 3.8.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45539">#45539</a></li>
<li>Upgrade to Elasticsearch 8.18.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45447">#45447</a></li>
<li>Upgrade to GraphQL Java 24.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45588">#45588</a></li>
<li>Upgrade to Hibernate 6.6.15.Final <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45540">#45540</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/8c2d6453243f319accaef7a190ff8ddf89f482a2"><code>8c2d645</code></a> Release v3.5.0</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/0b49e78c21f5afaf2db23bea2a1f8b369b3d92a7"><code>0b49e78</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c684fa4050d89a505f28257fef5462745671b6e5"><code>c684fa4</code></a> Switch <code>make-default</code> for publish-to-sdkman to 3.5.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/569519285046967a85f20cefe4200fcfc35a21c8"><code>5695192</code></a> Ensure descendants are always recalculated on cache refresh</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/31f549efc699e8f2f597ddf08bb572ad9a74b358"><code>31f549e</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/68df6f594167d760e67dd97eed0783e3f3a5fafd"><code>68df6f5</code></a> Next development version (v3.4.7-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/9f46877c7ea17452f1f744281aa0008fadcc82f9"><code>9f46877</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/404a0df5e8cffad3c9cbc896b0382347586102bf"><code>404a0df</code></a> Merge branch '3.3.x' into 3.4.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/e331846302f763905e9e0d3cf96438f60c7bd3c4"><code>e331846</code></a> Next development version (v3.3.13-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/b142798bdb8dde5d8a6ab01e70d6d78c1a6752c7"><code>b142798</code></a> Merge branch '3.4.x'</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v3.4.5...v3.5.0">compare view</a></li>
</ul>
</details>
<br />

Updates `org.springframework.boot` from 3.4.5 to 3.5.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot's releases</a>.</em></p>
<blockquote>
<h2>v3.5.0</h2>
<p>Full <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes">release notes for Spring Boot 3.5</a> are available on the wiki.</p>
<h2>:star: New Features</h2>
<ul>
<li>Make heapdump endpoint restricted by default <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45624">#45624</a></li>
<li>Remove SSL status tag from metrics <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45602">#45602</a></li>
<li>Remove 'spring.http.client' deprecation and change 'spring.http.reactiveclient.settings' to 'spring.http.reactiveclient' <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45507">#45507</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Unable to override/set nested ConfigurationProperties by passing as a system property <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45639">#45639</a></li>
<li>ValidationAutoConfiguration triggers early initialization of properties binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45618">#45618</a></li>
<li>Micrometer &quot;enable&quot; annotations property does not cover observed aspect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45617">#45617</a></li>
<li>spring.graphql.sse.timeout is no longer exposed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45613">#45613</a></li>
<li>SpringApplication.setEnvironmentPrefix is ignored when reading SPRING_PROFILES_ACTIVE <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45549">#45549</a></li>
<li>IllegalStateException when extracting using layers a module with no code of its own <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45449">#45449</a></li>
<li>Removed spring.batch.initialize-schema property is still considered <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45380">#45380</a></li>
<li>ReactorHttpClientBuilder does not offer a factory method to create the HttpClient <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45378">#45378</a></li>
<li>Suggested values for spring.jpa.hibernate.ddl-auto are not aligned with Hibernate <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45351">#45351</a></li>
<li>Custom default units declared on a field are ignored when binding properties in a native image <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45347">#45347</a></li>
<li>DockerRegistryConfigAuthentication uses the wrong serverUrl as a fallback for the Credentials helper <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45345">#45345</a></li>
<li>Various spring.datasource properties are mistakenly marked as ignored <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45342">#45342</a></li>
<li>JerseyWebApplicationInitializer always gets loaded, setting a ServletContext initParameter <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45297">#45297</a></li>
<li>DockerRegistryConfigAuthentication does not align with Docker CLI <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45292">#45292</a></li>
<li>Unlike the Docker CLI, &quot;\x00&quot; characters are not trimmed from a decoded Docker Registry password <a href="https://redirect.github.com/spring-projects/spring-boot/pull/45290">#45290</a></li>
<li>CloudFoundry security matcher logs a warning due to use of the 'ignoring()' method <a href="https://redirect.github.com/spring-projects/spring-boot/issues/32622">#32622</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Document the java info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45634">#45634</a></li>
<li>Document the process info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45632">#45632</a></li>
<li>Document the os info contribution <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45630">#45630</a></li>
<li>Document typical spring.application.group and name use <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45628">#45628</a></li>
<li>Document that bean methods should be static when annotated with <code>@ConfigurationPropertiesBinding</code> <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45626">#45626</a></li>
<li>Document the way that primary Kotlin constructors are used when binding <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45553">#45553</a></li>
<li>Improve &quot;profile&quot; reference documentation with additional admonitions  <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45551">#45551</a></li>
<li>Improve setEnvironmentPrefix(...) reference documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45376">#45376</a></li>
<li>Document all the available Testcontainers integrations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45367">#45367</a></li>
<li>Document when a spring.config.import value is relative and when it is fixed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45363">#45363</a></li>
<li>Update org.cyclonedx.bom version in docs to 2.3.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45320">#45320</a></li>
<li>Update link to &quot;Parameter Name Retention&quot; section of Spring Framework's release notes <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45299">#45299</a></li>
</ul>
<h2>:hammer: Dependency Upgrades</h2>
<ul>
<li>Prevent upgrade to Prometheus Client 1.3.7 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45541">#45541</a></li>
<li>Upgrade to Couchbase Client 3.8.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45539">#45539</a></li>
<li>Upgrade to Elasticsearch 8.18.1 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45447">#45447</a></li>
<li>Upgrade to GraphQL Java 24.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45588">#45588</a></li>
<li>Upgrade to Hibernate 6.6.15.Final <a href="https://redirect.github.com/spring-projects/spring-boot/issues/45540">#45540</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/8c2d6453243f319accaef7a190ff8ddf89f482a2"><code>8c2d645</code></a> Release v3.5.0</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/0b49e78c21f5afaf2db23bea2a1f8b369b3d92a7"><code>0b49e78</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c684fa4050d89a505f28257fef5462745671b6e5"><code>c684fa4</code></a> Switch <code>make-default</code> for publish-to-sdkman to 3.5.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/569519285046967a85f20cefe4200fcfc35a21c8"><code>5695192</code></a> Ensure descendants are always recalculated on cache refresh</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/31f549efc699e8f2f597ddf08bb572ad9a74b358"><code>31f549e</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/68df6f594167d760e67dd97eed0783e3f3a5fafd"><code>68df6f5</code></a> Next development version (v3.4.7-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/9f46877c7ea17452f1f744281aa0008fadcc82f9"><code>9f46877</code></a> Merge branch '3.4.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/404a0df5e8cffad3c9cbc896b0382347586102bf"><code>404a0df</code></a> Merge branch '3.3.x' into 3.4.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/e331846302f763905e9e0d3cf96438f60c7bd3c4"><code>e331846</code></a> Next development version (v3.3.13-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/b142798bdb8dde5d8a6ab01e70d6d78c1a6752c7"><code>b142798</code></a> Merge branch '3.4.x'</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v3.4.5...v3.5.0">compare view</a></li>
</ul>
</details>
<br />

Updates `com.nimbusds:nimbus-jose-jwt` from 10.2 to 10.3
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt">com.nimbusds:nimbus-jose-jwt's changelog</a>.</em></p>
<blockquote>
<p>10.2 (2025-04-07)
* Gson is made a direct instead of a shaded dependency to address module
issues introduced in 10.1 (iss <a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/550">#550</a>).</p>
<p>10.3 (2025-05-09)
* Restores the Gson shading, adding placeholder interfaces to prevent
NoClassDefFoundError occurrences at runtime when the JAR is used on a
module path (iss <a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/550">#550</a>).</p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/a988a2d5cdc9d5b55afc11a52f92232e67bc5697"><code>a988a2d</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/5fa1dc9a25379500263ebc582cc1efa27b8101f4"><code>5fa1dc9</code></a> shade gson again</li>
<li><a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/800db7b1ab2d1d7b4171056112dc755a211115a1"><code>800db7b</code></a> Merged in feature/shaded-gson (pull request <a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/127">#127</a>)</li>
<li><a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/f474bcfa68ef3f4bc5bc8fec37add01fa1f3d42a"><code>f474bcf</code></a> Adds change log entry for 10.3 (iss <a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/550">#550</a>)</li>
<li><a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/c1f3c4441041c0f625c989a6d0a97d77401c033e"><code>c1f3c44</code></a> [maven-release-plugin] prepare release 10.3</li>
<li>See full diff in <a href="https://bitbucket.org/connect2id/nimbus-jose-jwt/branches/compare/10.3..10.2">compare view</a></li>
</ul>
</details>
<br />

Updates `io.projectreactor.netty:reactor-netty-http` from 1.2.5 to 1.2.6
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/reactor/reactor-netty/releases">io.projectreactor.netty:reactor-netty-http's releases</a>.</em></p>
<blockquote>
<h2>v1.2.6</h2>
<!-- raw HTML omitted -->
<p><code>Reactor Netty</code> <code>1.2.6</code> is part of <strong><code>2024.0.6</code> Release Train</strong>.</p>
<h2>What's Changed</h2>
<h3>:sparkles: New features and improvements</h3>
<ul>
<li>Depend on <code>Reactor Core</code> <code>v3.7.6</code> by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in b6e72c423245595c39ef00faa818e0109c96b57b, see <a href="https://github.com/reactor/reactor-core/releases/tag/v3.7.6">release notes</a></li>
<li>Depend on <code>Netty</code> <code>v4.1.121.Final</code> by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3728">#3728</a></li>
<li>Depend on <code>Netty QUIC Codec</code> <code>v0.0.72.Final</code> by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3737">#3737</a></li>
<li>Make <code>AccessLog</code> class not final by <a href="https://github.com/dmitrysulman"><code>@​dmitrysulman</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3726">#3726</a></li>
<li>Add request and response header iterators to <code>AccessLogArgProvider</code> by <a href="https://github.com/dmitrysulman"><code>@​dmitrysulman</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3735">#3735</a></li>
<li>Support error log handler for Http server by <a href="https://github.com/raccoonback"><code>@​raccoonback</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3700">#3700</a> and by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in 4ed2380d4a866e7577c1785c6efd8caa9675ff76 and <a href="https://redirect.github.com/reactor/reactor-netty/issues/3750">#3750</a></li>
<li>Remove unused method parameter by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3751">#3751</a></li>
</ul>
<h3>:lady_beetle: Bug fixes</h3>
<ul>
<li>Ensure <code>reactor.netty.http.server.connections.active</code> is updated when there is no <code>HttpServerOperations</code> by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3725">#3725</a></li>
<li>Ensure the default compression configuration is taken from Netty by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3743">#3743</a></li>
<li>Ensure the exception is propagated in case of delayed address resolution by <a href="https://github.com/violetagg"><code>@​violetagg</code></a> in <a href="https://redirect.github.com/reactor/reactor-netty/issues/3744">#3744</a></li>
<li>Release the partial <code>HttpData</code> only if it is not released by Netty by <a href="https://github.com/violetagg"><code>@​violetagg</code></...

_Description has been truncated_