### PR TITLE
CORE-536: slim down RBS's otel/GCP exporters dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,10 +84,11 @@ dependencies {
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
+    //    ... are specified by terra-common-lib, so we don't need to specify them here.
     // upgrading to 0.35.0 causes integration tests to fail. Why?
-    var gcpOpenTelemetryExporterVersion = '0.35.0'
-    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
-    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
+//    var gcpOpenTelemetryExporterVersion = '0.35.0'
+//    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
+//    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 
     // Deps whose versions are controlled by Spring
     implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: '2.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -83,13 +83,8 @@ dependencies {
     implementation group: 'org.webjars', name: 'webjars-locator-core', version: '0.59'
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
-    // Google cloud open telemetry exporters
-//    //    ... are specified by terra-common-lib; we should use the same versions here.
-//    var gcpOpenTelemetryExporterVersion = '0.35.0'
-//    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
-//    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
-    // need to pull in the opentelemetry sdk because some classes use its objects directly.
-    // otel version should match the same version used by Spring Boot and terra-common-lib.
+    // Pull in the opentelemetry sdk because some classes use its objects directly.
+    // This otel version should match the same version used by Spring Boot and terra-common-lib.
     var openTelemetrySdkVersion = '1.49.0'
     implementation "io.opentelemetry:opentelemetry-sdk:${openTelemetrySdkVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 
     // Google cloud open telemetry exporters
     // upgrading to 0.35.0 causes integration tests to fail. Why?
-    var gcpOpenTelemetryExporterVersion = '0.34.0'
+    var gcpOpenTelemetryExporterVersion = '0.35.0'
     implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,14 @@ dependencies {
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
-    //    ... are specified by terra-common-lib; we should use the same versions here.
-    var gcpOpenTelemetryExporterVersion = '0.35.0'
-    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
-    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
-
+//    //    ... are specified by terra-common-lib; we should use the same versions here.
+//    var gcpOpenTelemetryExporterVersion = '0.35.0'
+//    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
+//    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
+    // need to pull in the opentelemetry sdk because some classes use its objects directly.
+    // otel version should match the same version used by Spring Boot and terra-common-lib.
+    var openTelemetrySdkVersion = '1.49.0'
+    implementation "io.opentelemetry:opentelemetry-sdk:${openTelemetrySdkVersion}"
 
     // Deps whose versions are controlled by Spring
     implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: '2.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,11 @@ dependencies {
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
-    //    ... are specified by terra-common-lib, so we don't need to specify them here.
-    // upgrading to 0.35.0 causes integration tests to fail. Why?
-//    var gcpOpenTelemetryExporterVersion = '0.35.0'
-//    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
-//    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
+    //    ... are specified by terra-common-lib; we should use the same versions here.
+    var gcpOpenTelemetryExporterVersion = '0.35.0'
+    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
+    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
+
 
     // Deps whose versions are controlled by Spring
     implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: '2.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
-    var gcpOpenTelemetryExporterVersion = '0.34.0'
+    var gcpOpenTelemetryExporterVersion = '0.35.0'
     implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,8 @@ dependencies {
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Google cloud open telemetry exporters
-    var gcpOpenTelemetryExporterVersion = '0.35.0'
+    // upgrading to 0.35.0 causes integration tests to fail. Why?
+    var gcpOpenTelemetryExporterVersion = '0.34.0'
     implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,7 @@ spring:
 
 otel:
   sdk:
-    disabled: true # set to true to disable all open telemetry features
+    disabled: false # set to true to disable all open telemetry features
 
   springboot:
     resource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,13 @@ spring:
     static-locations: classpath:/api/
 
 otel:
+  metrics:
+    exporter: none
+  traces:
+    exporter: none
+  metrics-exporter: none
+  traces-exporter: none
+
   sdk:
     disabled: false # set to true to disable all open telemetry features
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,7 @@ spring:
 
 otel:
   sdk:
-    disabled: false # set to true to disable all open telemetry features
+    disabled: true # set to true to disable all open telemetry features
 
   springboot:
     resource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,13 +67,6 @@ spring:
     static-locations: classpath:/api/
 
 otel:
-  metrics:
-    exporter: none
-  traces:
-    exporter: none
-  metrics-exporter: none
-  traces-exporter: none
-
   sdk:
     disabled: false # set to true to disable all open telemetry features
 


### PR DESCRIPTION
Previously, RBS declared `com.google.cloud.opentelemetry:exporter-trace` and `com.google.cloud.opentelemetry:exporter-metrics` as dependencies.

This PR removes those imports and replaces them with `io.opentelemetry:opentelemetry-sdk`.

RBS has some code ([example](https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/common/MetricsHelper.java)) that directly accesses OpenTelemetry classes, so some kind of dependency is needed. However, the GCP exporters are not necessary for the code to compile; only the otel SDK is needed.

TCL, which RBS also depends on, specifies the GCP exporters so should already be configured to push to GCP.

This PR is an attempt to bypass the errors in #433.

I have verified, by running RBS locally, that RBS's custom metrics are still reported up to GCP:
![Screenshot 18-06-2025 at 10 34 (2)](https://github.com/user-attachments/assets/df15e709-8f8f-4d76-a2a7-33940e301d54)

