### PR TITLE
[AN-655] Add new pool configs without LifeSciences API

### DIFF
--- a/src/main/resources/config/buffertest/pool_schema.yml
+++ b/src/main/resources/config/buffertest/pool_schema.yml
@@ -4,3 +4,6 @@ poolConfigs:
   - poolId: "resource_buffer_test_v3"
     size: 0
     resourceConfigName: "resource_buffer_test_v3"
+  - poolId: "resource_buffer_test_v4"
+    size: 0
+    resourceConfigName: "resource_buffer_test_v4"

--- a/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v4.yml
+++ b/src/main/resources/config/buffertest/resource-config/resource_buffer_test_v4.yml
@@ -1,0 +1,34 @@
+# Resource template for running buffer service performance test
+---
+configName: "resource_buffer_test_v4"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "buffer-test"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/tools/buffertest
+  parentFolderId: "339691735869"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  iamBindings:
+    - members: [ "group:terra-rbs-test@broadinstitute.org" ]
+      role: "roles/editor"
+    - members: [ "group:terra-rbs-viewer-test@broadinstitute.org" ]
+      role: "roles/viewer"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/dev/pool_schema.yml
+++ b/src/main/resources/config/dev/pool_schema.yml
@@ -4,6 +4,9 @@ poolConfigs:
   - poolId: "cwb_ws_dev_v8"
     size: 100
     resourceConfigName: "cwb_ws_resource_dev_v8"
+  - poolId: "cwb_ws_dev_v9"
+    size: 100
+    resourceConfigName: "cwb_ws_resource_dev_v9"
   - poolId: "datarepo_fakeprod_v1"
     size: 50
     resourceConfigName: "datarepo_fakeprod_v1"
@@ -13,6 +16,12 @@ poolConfigs:
   - poolId: "vpc_sc_v13"
     size: 100
     resourceConfigName: "vpc_sc_v13"
+  - poolId: "vpc_sc_v14"
+    size: 100
+    resourceConfigName: "vpc_sc_v14"
   - poolId: "workspace_manager_v12"
     size: 50
     resourceConfigName: "workspace_manager_v12"
+  - poolId: "workspace_manager_v13"
+    size: 50
+    resourceConfigName: "workspace_manager_v13"

--- a/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v9.yml
+++ b/src/main/resources/config/dev/resource-config/cwb_ws_resource_dev_v9.yml
@@ -1,0 +1,32 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_resource_dev_v9"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-dev"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/dev/CommunityWorkbench
+  parentFolderId: "803412578462"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/dev/resource-config/vpc_sc_v14.yml
+++ b/src/main/resources/config/dev/resource-config/vpc_sc_v14.yml
@@ -1,0 +1,41 @@
+# # Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v14"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-dev"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/dev/for_vpc_sc_unclaimed
+  parentFolderId: "1061905712535"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "serviceusage.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    enableArtifactRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  serviceUsage:
+    bigQuery:
+      overrideBigQueryDailyUsageQuota: true
+      bigQueryDailyUsageQuotaOverrideValueMebibytes: 38146972 # 40 TB
+  securityGroup: "high"

--- a/src/main/resources/config/dev/resource-config/workspace_manager_v13.yml
+++ b/src/main/resources/config/dev/resource-config/workspace_manager_v13.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v13"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-d"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "421312654454" #test.firecloud.org/dev/buffer-dev/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "bigquerydatatransfer.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/prod/pool_schema.yml
+++ b/src/main/resources/config/prod/pool_schema.yml
@@ -4,9 +4,15 @@ poolConfigs:
   - poolId: "cwb_ws_prod_v8"
     size: 1000
     resourceConfigName: "cwb_ws_prod_v8"
+  - poolId: "cwb_ws_prod_v9"
+    size: 1000
+    resourceConfigName: "cwb_ws_prod_v9"
   - poolId: "datarepo_v1"
     size: 1000
     resourceConfigName: "datarepo_v1"
   - poolId: "vpc_sc_v12"
     size: 1000
     resourceConfigName: "vpc_sc_v12"
+  - poolId: "vpc_sc_v13"
+    size: 1000
+    resourceConfigName: "vpc_sc_v13"

--- a/src/main/resources/config/prod/resource-config/cwb_ws_prod_v9.yml
+++ b/src/main/resources/config/prod/resource-config/cwb_ws_prod_v9.yml
@@ -1,0 +1,32 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_prod_v9"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra"
+    scheme: "RANDOM_CHAR"
+  # firecloud.org/prod/CommunityWorkbench
+  parentFolderId: "710468670182"
+  billingAccount: "0106B0-41CAA9-427C96"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/prod/resource-config/vpc_sc_v13.yml
+++ b/src/main/resources/config/prod/resource-config/vpc_sc_v13.yml
@@ -1,0 +1,41 @@
+# Projects with VPC-SC configuration
+---
+configName: "vpc_sc_v13"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc"
+    scheme: "RANDOM_CHAR"
+  # firecloud.org/prod/for_vpc_sc_unclaimed
+  parentFolderId: "160283235721"
+  billingAccount: "0106B0-41CAA9-427C96"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "serviceusage.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    enableArtifactRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  serviceUsage:
+    bigQuery:
+      overrideBigQueryDailyUsageQuota: true
+      bigQueryDailyUsageQuotaOverrideValueMebibytes: 38146972 # 40 TB
+  securityGroup: "high"

--- a/src/main/resources/config/staging/pool_schema.yml
+++ b/src/main/resources/config/staging/pool_schema.yml
@@ -4,9 +4,15 @@ poolConfigs:
   - poolId: "cwb_ws_staging_v8"
     size: 100
     resourceConfigName: "cwb_ws_resource_staging_v8"
+  - poolId: "cwb_ws_staging_v9"
+    size: 100
+    resourceConfigName: "cwb_ws_resource_staging_v9"
   - poolId: "datarepo_v1"
     size: 100
     resourceConfigName: "datarepo_v1"
   - poolId: "vpc_sc_v7"
     size: 100
     resourceConfigName: "vpc_sc_v7"
+  - poolId: "vpc_sc_v8"
+    size: 100
+    resourceConfigName: "vpc_sc_v8"

--- a/src/main/resources/config/staging/resource-config/cwb_ws_resource_staging_v9.yml
+++ b/src/main/resources/config/staging/resource-config/cwb_ws_resource_staging_v9.yml
@@ -1,0 +1,32 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_resource_staging_v9"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-staging"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/staging/CommunityWorkbench
+  parentFolderId: "137690849844"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/staging/resource-config/vpc_sc_v8.yml
+++ b/src/main/resources/config/staging/resource-config/vpc_sc_v8.yml
@@ -1,0 +1,34 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_v8"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-staging"
+    scheme: "RANDOM_CHAR"
+  # test.firecloud.org/staging/for_vpc_sc_unclaimed
+  parentFolderId: "119547684332"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+  - "bigquery-json.googleapis.com"
+  - "batch.googleapis.com"
+  - "compute.googleapis.com"
+  - "container.googleapis.com"
+  - "containerregistry.googleapis.com"
+  - "cloudbilling.googleapis.com"
+  - "clouderrorreporting.googleapis.com"
+  - "cloudkms.googleapis.com"
+  - "cloudtrace.googleapis.com"
+  - "dataflow.googleapis.com"
+  - "dataproc.googleapis.com"
+  - "dns.googleapis.com"
+  - "logging.googleapis.com"
+  - "monitoring.googleapis.com"
+  - "storage-api.googleapis.com"
+  - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"

--- a/src/main/resources/config/tools/pool_schema.yml
+++ b/src/main/resources/config/tools/pool_schema.yml
@@ -5,12 +5,21 @@ poolConfigs:
   - poolId: "cwb_ws_quality_v11"
     size: 200
     resourceConfigName: "cwb_ws_resource_quality_v11"
+  - poolId: "cwb_ws_quality_v12"
+    size: 200
+    resourceConfigName: "cwb_ws_resource_quality_v12"
   - poolId: "datarepo_v1"
     size: 2000
     resourceConfigName: "datarepo_v1"
   - poolId: "vpc_sc_qa-fiab_v6"
     size: 100
     resourceConfigName: "vpc_sc_qa-fiab_v6"
+  - poolId: "vpc_sc_qa-fiab_v7"
+    size: 100
+    resourceConfigName: "vpc_sc_qa-fiab_v7"
   - poolId: "workspace_manager_v12"
     size: 100
     resourceConfigName: "workspace_manager_v12"
+  - poolId: "workspace_manager_v13"
+    size: 100
+    resourceConfigName: "workspace_manager_v13"

--- a/src/main/resources/config/tools/resource-config/cwb_ws_resource_quality_v12.yml
+++ b/src/main/resources/config/tools/resource-config/cwb_ws_resource_quality_v12.yml
@@ -1,0 +1,36 @@
+# Community Workbench buffered workspace template
+---
+configName: "cwb_ws_resource_quality_v12"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-quality"
+    scheme: "RANDOM_CHAR"
+  # quality.firecloud.org/quality/CommunityWorkbench
+  parentFolderId: "180789000311"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+    - "networkmanagement.googleapis.com"
+    - "iap.googleapis.com"
+  network:
+    enableNetworkMonitoring: "false"
+    enablePrivateGoogleAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v7.yml
+++ b/src/main/resources/config/tools/resource-config/vpc_sc_qa-fiab_v7.yml
@@ -1,0 +1,34 @@
+# Community Workbench buffered workspace template
+---
+configName: "vpc_sc_qa-fiab_v7"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-vpc-sc-qafiab"
+    scheme: "RANDOM_CHAR"
+  # quality.firecloud.org/quality/for_vpc_sc_unclaimed
+  parentFolderId: "108325210767"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  computeEngine:
+    keepDefaultServiceAcct: "true"

--- a/src/main/resources/config/tools/resource-config/workspace_manager_v13.yml
+++ b/src/main/resources/config/tools/resource-config/workspace_manager_v13.yml
@@ -1,0 +1,30 @@
+# Workspace Manager buffered workspace template
+---
+configName: "workspace_manager_v13"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-wsm-t"
+    scheme: "TWO_WORDS_NUMBER"
+  parentFolderId: "375605435272" #test.firecloud.org/tools/buffer-tools/workspace_manager
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "bigquerydatatransfer.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "notebooks.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"

--- a/src/main/resources/config/toolsalpha/pool_schema.yml
+++ b/src/main/resources/config/toolsalpha/pool_schema.yml
@@ -4,3 +4,6 @@ poolConfigs:
   - poolId: "resource_toolsalpha_v9"
     size: 5
     resourceConfigName: "resource_toolsalpha_v9"
+  - poolId: "resource_toolsalpha_v10"
+    size: 5
+    resourceConfigName: "resource_toolsalpha_v10"

--- a/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v10.yml
+++ b/src/main/resources/config/toolsalpha/resource-config/resource_toolsalpha_v10.yml
@@ -1,0 +1,40 @@
+# Resource template for local testing and personal environment on GKE
+---
+configName: "resource_toolsalpha_v10"
+gcpProjectConfig:
+  projectIdSchema:
+    prefix: "terra-toolsalpha"
+    scheme: "RANDOM_CHAR"
+  # RBS Testing
+  parentFolderId: "637867149294"
+  billingAccount: "01A82E-CA8A14-367457"
+  enabledApis:
+    - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
+    - "compute.googleapis.com"
+    - "container.googleapis.com"
+    - "cloudbilling.googleapis.com"
+    - "clouderrorreporting.googleapis.com"
+    - "cloudkms.googleapis.com"
+    - "cloudtrace.googleapis.com"
+    - "containerregistry.googleapis.com"
+    - "dataflow.googleapis.com"
+    - "dataproc.googleapis.com"
+    - "dns.googleapis.com"
+    - "logging.googleapis.com"
+    - "monitoring.googleapis.com"
+    - "storage-api.googleapis.com"
+    - "storage-component.googleapis.com"
+  network:
+    enableNetworkMonitoring: "true"
+    enablePrivateGoogleAccess: "true"
+    enableCloudRegistryPrivateGoogleAccess: "true"
+    blockBatchInternetAccess: "true"
+  kubernetesEngine:
+    createGkeDefaultServiceAccount: "true"
+  iamBindings:
+    - members: ["group:terra-rbs-test@broadinstitute.org"]
+      role: "roles/editor"
+    - members: ["group:terra-rbs-viewer-test@broadinstitute.org"]
+      role: "roles/viewer"
+  securityGroup: "high"

--- a/src/test/java/bio/terra/buffer/config/resource-config/..data/ws_0_0_2.yml
+++ b/src/test/java/bio/terra/buffer/config/resource-config/..data/ws_0_0_2.yml
@@ -10,6 +10,7 @@ gcpProjectConfig:
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
     - "compute.googleapis.com"
     - "container.googleapis.com"
     - "cloudbilling.googleapis.com"
@@ -19,7 +20,6 @@ gcpProjectConfig:
     - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
-    - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"

--- a/src/test/resources/test/config/resource-config/ws_0_0_2.yml
+++ b/src/test/resources/test/config/resource-config/ws_0_0_2.yml
@@ -10,6 +10,7 @@ gcpProjectConfig:
   billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
+    - "batch.googleapis.com"
     - "compute.googleapis.com"
     - "container.googleapis.com"
     - "cloudbilling.googleapis.com"
@@ -19,7 +20,6 @@ gcpProjectConfig:
     - "containerregistry.googleapis.com"
     - "dataflow.googleapis.com"
     - "dataproc.googleapis.com"
-    - "lifesciences.googleapis.com"
     - "logging.googleapis.com"
     - "monitoring.googleapis.com"
     - "storage-api.googleapis.com"


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/AN-655

LifeSciences API is going to be shutdown on July 8th. To prepare for that, this PR adds new pool configs without LifeSciences API