### PR TITLE
[CORE-593] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ pom.xml
 *.zip
 *.tar.gz
 *.rar
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
In order to complete https://broadworkbench.atlassian.net/browse/CORE-593, service account auth will need to be added. Preemptively updating .gitignore to avoid committing any creds. Actual PR for CORE-593 will come later