### PR TITLE
[CORE-593] Switch from jfrog to GAR

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,26 +1,6 @@
-//def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-snapshot-local'
-//def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
-//def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
-//
-//gradle.taskGraph.whenReady { taskGraph ->
-//    if (taskGraph.hasTask(artifactoryPublish) &&
-//            (artifactory_username == null || artifactory_password == null)) {
-//        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
-//    }
-//}
-
 def garProjectId = System.getenv("GOOGLE_CLOUD_PROJECT")
 def garLocation = System.getenv("GAR_LOCATION")
 def garRepoId = System.getenv("GAR_REPOSITORY_ID")
-
-
-
-
-//java {
-//    // Builds sources into the published package as part of the 'assemble' task.
-//    withSourcesJar()
-//}
-
 
 publishing {
     publications {
@@ -39,20 +19,3 @@ publishing {
         }
     }
 }
-
-// Upload Maven artifacts to Artifactory using the Artifactory plugin.
-//artifactory {
-//    publish {
-//        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-//        repository {
-//            repoKey = "${artifactory_repo_key}"
-//            username = "${artifactory_username}"
-//            password = "${artifactory_password}"
-//        }
-//        defaults {
-//            publications('bufferClientLibrary')
-//            publishArtifacts = true
-//            publishPom = true
-//        }
-//    }
-//}

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,13 +1,26 @@
-def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-snapshot-local'
-def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
-def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
+//def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-snapshot-local'
+//def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
+//def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
+//
+//gradle.taskGraph.whenReady { taskGraph ->
+//    if (taskGraph.hasTask(artifactoryPublish) &&
+//            (artifactory_username == null || artifactory_password == null)) {
+//        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
+//    }
+//}
 
-gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.hasTask(artifactoryPublish) &&
-            (artifactory_username == null || artifactory_password == null)) {
-        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
-    }
-}
+def garProjectId = System.getenv("GOOGLE_CLOUD_PROJECT")
+def garLocation = System.getenv("GAR_LOCATION")
+def garRepoId = System.getenv("GAR_REPOSITORY_ID")
+
+
+
+
+//java {
+//    // Builds sources into the published package as part of the 'assemble' task.
+//    withSourcesJar()
+//}
+
 
 publishing {
     publications {
@@ -20,21 +33,26 @@ publishing {
             }
         }
     }
-}
-
-// Upload Maven artifacts to Artifactory using the Artifactory plugin.
-artifactory {
-    publish {
-        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-        repository {
-            repoKey = "${artifactory_repo_key}"
-            username = "${artifactory_username}"
-            password = "${artifactory_password}"
-        }
-        defaults {
-            publications('bufferClientLibrary')
-            publishArtifacts = true
-            publishPom = true
+    repositories {
+        maven {
+            url = uri("artifactregistry://${garLocation}-maven.pkg.dev/${garProjectId}/${garRepoId}")
         }
     }
 }
+
+// Upload Maven artifacts to Artifactory using the Artifactory plugin.
+//artifactory {
+//    publish {
+//        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
+//        repository {
+//            repoKey = "${artifactory_repo_key}"
+//            username = "${artifactory_username}"
+//            password = "${artifactory_password}"
+//        }
+//        defaults {
+//            publications('bufferClientLibrary')
+//            publishArtifacts = true
+//            publishPom = true
+//        }
+//    }
+//}

--- a/terra-resource-buffer-client/README.md
+++ b/terra-resource-buffer-client/README.md
@@ -1,7 +1,12 @@
 # terra-resource-buffer-client
 Terra Resource Buffering Service Client Library
 ## Publish a new version
+Make sure you are logged in to your @broad account.  You may not have permission to publish; if not, contact Devops.
 Update the version in `gradle.properties` file, then run
 ```
 ./publish.sh
+```
+By default, this publishes to the snapshot repo; if you want to publish to the release repo, then use the `release` flag:
+```
+./publish.sh release
 ```

--- a/terra-resource-buffer-client/build.gradle
+++ b/terra-resource-buffer-client/build.gradle
@@ -2,8 +2,9 @@ plugins {
     id 'java-library'
     id 'maven-publish'
 
-    id 'com.jfrog.artifactory' version '5.2.5'
+//    id 'com.jfrog.artifactory' version '5.2.5'
     id 'org.hidetake.swagger.generator' version '2.19.2'
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.1.5'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8 // Rawls consumes this and is Java 8

--- a/terra-resource-buffer-client/build.gradle
+++ b/terra-resource-buffer-client/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java-library'
     id 'maven-publish'
 
-//    id 'com.jfrog.artifactory' version '5.2.5'
     id 'org.hidetake.swagger.generator' version '2.19.2'
     id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.1.5'
 }

--- a/terra-resource-buffer-client/publish.sh
+++ b/terra-resource-buffer-client/publish.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
-# Copied from Terra Janitor repo
-# Publish Terra Resource Buffer Service Client Package:
-VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
-DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
-ARTIFACTORY_ACCOUNT_PATH=secret/dsp/accts/artifactory/dsdejenkins
-
-export ARTIFACTORY_USERNAME=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
- vault read -field username ${ARTIFACTORY_ACCOUNT_PATH})
-export ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
- vault read -field password ${ARTIFACTORY_ACCOUNT_PATH})
+export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
+export GAR_LOCATION=us-central1
+export GAR_REPOSITORY_ID=libs-snapshot-standard
 ./gradlew test
-./gradlew artifactoryPublish
+./gradlew publish

--- a/terra-resource-buffer-client/publish.sh
+++ b/terra-resource-buffer-client/publish.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
+
+# Default to snapshot repository
+REPO_TYPE=${1:-snapshot}
+
 export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
 export GAR_LOCATION=us-central1
-export GAR_REPOSITORY_ID=libs-snapshot-standard
+
+if [ "$REPO_TYPE" = "release" ]; then
+    export GAR_REPOSITORY_ID=libs-release-standard
+    echo "Publishing to release repository: $GAR_REPOSITORY_ID"
+else
+    export GAR_REPOSITORY_ID=libs-snapshot-standard
+    echo "Publishing to snapshot repository: $GAR_REPOSITORY_ID"
+fi
+
 ./gradlew test
 ./gradlew publish


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-593

As far as I can tell, resource buffer is published as an image to GCR.  It was only published to jfrog through a manually-run `publish.sh` script, which I've updated.