### PR TITLE
CORE-69: ignore jackson 2.19.2 for buildScript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,9 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[CORE-69]"
+    ignore:
+      # Jackson 2.19.2 is only specified for the `buildScript` classpath.
+      # As of this writing, Jib requires this specific version, and we want Dependabot
+      # to leave it alone.
+      - dependency-name: "com.fasterxml.jackson:jackson-bom"
+        versions: [ "2.19.2" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,6 @@ updates:
     ignore:
       # Jackson 2.19.2 is only specified for the `buildScript` classpath.
       # As of this writing, Jib requires this specific version, and we want Dependabot
-      # to leave it alone.
+      # to leave it alone. All other instances of jackson-bom are already updated to 2.20.0
       - dependency-name: "com.fasterxml.jackson:jackson-bom"
-        versions: [ "2.19.2" ]
+        versions: [ "2.20.0" ]

--- a/buffer-clienttests/build.gradle
+++ b/buffer-clienttests/build.gradle
@@ -28,7 +28,7 @@ dependencies {
         googleOauth2 = "1.39.1"
 
         bufferServiceClient = "0.4.3-SNAPSHOT"
-        testRunner = "0.2.1-SNAPSHOT"
+        testRunner = "0.2.2-SNAPSHOT"
     }
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"


### PR DESCRIPTION
Jackson 2.19.2 is only specified for the `buildScript` classpath.
As of this writing, Jib requires this specific version, and we want Dependabot to leave it alone.

This PR adds an ignore clause to `.github/dependabot.yml` to ignore the 2.20.0 update, which causes problems seen in #461. This will only be effective until jackson releases a higher version. I am struggling to come up with a better way to handle NOT updating the Jib-specific dependency.