### PR TITLE
[RW-17225] Use latest pool config when repairing google project

### DIFF
--- a/src/main/java/bio/terra/buffer/app/controller/ResourceApiController.java
+++ b/src/main/java/bio/terra/buffer/app/controller/ResourceApiController.java
@@ -31,7 +31,7 @@ public class ResourceApiController implements ResourceApi {
     @Override
     public ResponseEntity<JobModel> repairResource(String projectId, Object requestBody) {
         GoogleProjectUid googleProjectUid = new GoogleProjectUid().projectId(projectId);
-        Pool pool = poolService.getPoolForGoogleProject(googleProjectUid);
+        Pool pool = poolService.getLatestActivePoolForProject(googleProjectUid);
         Optional<String> flightId = flightScheduler.submitRepairResourceFlight(pool, googleProjectUid);
         return jobToResponse(jobService.retrieveJob(flightId.get()));
     }

--- a/src/main/java/bio/terra/buffer/common/PoolId.java
+++ b/src/main/java/bio/terra/buffer/common/PoolId.java
@@ -14,6 +14,10 @@ public abstract class PoolId {
     return new AutoValue_PoolId(id);
   }
 
+  public String family() {
+    return id().replaceAll("_v\\d+$", "");
+  }
+
   @Override
   public String toString() {
     return id();

--- a/src/main/java/bio/terra/buffer/db/BufferDao.java
+++ b/src/main/java/bio/terra/buffer/db/BufferDao.java
@@ -102,6 +102,23 @@ public class BufferDao {
     return jdbcTemplate.query(sql, POOL_ROW_MAPPER);
   }
 
+  /** Retrieves the latest active pool whose ID matches the given family prefix. */
+  @Transactional(propagation = Propagation.SUPPORTS)
+  public Optional<Pool> retrieveLatestActivePoolByFamily(String family) {
+    String sql =
+        "select p.id, p.resource_config, p.resource_type, p.creation, p.size, p.status "
+            + "FROM pool p "
+            + "WHERE p.id LIKE :family_pattern AND p.status = :status "
+            + "ORDER BY p.creation DESC LIMIT 1";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("family_pattern", family + "_v%")
+            .addValue("status", PoolStatus.ACTIVE.toString());
+
+    return Optional.ofNullable(
+        DataAccessUtils.singleResult(jdbcTemplate.query(sql, params, POOL_ROW_MAPPER)));
+  }
+
   /** Retrieves a pool with id. */
   @Transactional(propagation = Propagation.SUPPORTS)
   public Optional<Pool> retrievePool(PoolId poolId) {

--- a/src/main/java/bio/terra/buffer/service/pool/PoolService.java
+++ b/src/main/java/bio/terra/buffer/service/pool/PoolService.java
@@ -112,6 +112,45 @@ public class PoolService {
             .orElseThrow(() -> new NotFoundException(String.format("Pool for this resource does not exist: %s.", poolId)));
   }
 
+  /**
+   * Resolves the best pool to use when repairing a Google project. Looks up the resource's original
+   * pool, then attempts to find the latest active pool in the same family (e.g. cwb_ws_prod_v8 ->
+   * cwb_ws_prod_v9). Falls back to the original pool if no newer active pool exists.
+   */
+  public Pool getLatestActivePoolForProject(GoogleProjectUid projectId) {
+    CloudResourceUid cloudResourceUid = new CloudResourceUid().googleProjectUid(projectId);
+    Optional<Resource> resource = bufferDao.retrieveResource(cloudResourceUid);
+    if (resource.isEmpty()) {
+      throw new NotFoundException(String.format("Resource id does not exist: %s.", projectId));
+    }
+    PoolId originalPoolId = resource.get().poolId();
+    String family = originalPoolId.family();
+
+    Optional<Pool> latestPool = bufferDao.retrieveLatestActivePoolByFamily(family);
+    if (latestPool.isPresent()) {
+      if (!latestPool.get().id().equals(originalPoolId)) {
+        logger.info(
+            "Resolved latest active pool {} (family: {}) for resource originally in pool {}",
+            latestPool.get().id(),
+            family,
+            originalPoolId);
+      }
+      return latestPool.get();
+    }
+
+    logger.warn(
+        "No active pool found in family '{}' for pool {}; falling back to original pool",
+        family,
+        originalPoolId);
+    return bufferDao
+        .retrievePool(originalPoolId)
+        .orElseThrow(
+            () ->
+                new NotFoundException(
+                    String.format(
+                        "Pool for this resource does not exist: %s.", originalPoolId)));
+  }
+
   /** Process handout resource in on transaction (anything failure will cause database rollback). */
   private Resource handoutResourceTransactionally(
       PoolId poolId, RequestHandoutId requestHandoutId) {

--- a/src/test/java/bio/terra/buffer/app/controller/ResourceApiControllerTest.java
+++ b/src/test/java/bio/terra/buffer/app/controller/ResourceApiControllerTest.java
@@ -52,9 +52,9 @@ public class ResourceApiControllerTest {
     CloudResourceUid cloudResourceUid = new CloudResourceUid().googleProjectUid(googleProjectUid);
 
     Pool mockPool = Pool.builder()
-            .id(PoolId.create("test-pool"))
+            .id(PoolId.create("test-pool_v1"))
             .size(10)
-            .resourceConfig(new ResourceConfig()) // Use appropriate resource config
+            .resourceConfig(new ResourceConfig())
             .creation(BufferDao.currentInstant())
             .resourceType(ResourceType.GOOGLE_PROJECT)
             .status(PoolStatus.ACTIVE)
@@ -62,7 +62,7 @@ public class ResourceApiControllerTest {
 
     Resource mockResource = Resource.builder()
             .id(ResourceId.create(UUID.randomUUID()))
-            .poolId(PoolId.create("test-pool"))
+            .poolId(PoolId.create("test-pool_v1"))
             .cloudResourceUid(cloudResourceUid)
             .creation(BufferDao.currentInstant())
             .state(ResourceState.HANDED_OUT)
@@ -71,7 +71,7 @@ public class ResourceApiControllerTest {
 
     Mockito.when(bufferDao.retrieveResource(cloudResourceUid))
             .thenReturn(Optional.of(mockResource));
-    Mockito.when(mockBufferDAO.retrievePool(mockResource.poolId()))
+    Mockito.when(mockBufferDAO.retrieveLatestActivePoolByFamily("test-pool"))
             .thenReturn(Optional.of(mockPool));
     Mockito.when(mockFlightScheduler.submitRepairResourceFlight(mockPool, googleProjectUid))
             .thenReturn(Optional.of("flight-123"));
@@ -89,7 +89,7 @@ public class ResourceApiControllerTest {
             .perform(
                     post("/api/resource/v1/" + projectId + "/repair")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{}")) // no request body is needed for this endpoint
+                            .content("{}"))
             .andExpect(status().isAccepted())
             .andReturn()
             .getResponse()
@@ -99,6 +99,63 @@ public class ResourceApiControllerTest {
     assertEquals("flight-123", actualJob.getId());
     assertEquals("RepairResourceFlight", actualJob.getClassName());
     assertEquals(JobModel.JobStatusEnum.RUNNING, actualJob.getJobStatus());
+  }
+
+  @Test
+  public void repairResource_usesNewerActivePool() throws Exception {
+    String projectId = "test-project-id";
+    GoogleProjectUid googleProjectUid = new GoogleProjectUid().projectId(projectId);
+    CloudResourceUid cloudResourceUid = new CloudResourceUid().googleProjectUid(googleProjectUid);
+
+    PoolId oldPoolId = PoolId.create("cwb_ws_prod_v8");
+    PoolId newPoolId = PoolId.create("cwb_ws_prod_v9");
+
+    Pool newerPool = Pool.builder()
+            .id(newPoolId)
+            .size(10)
+            .resourceConfig(new ResourceConfig())
+            .creation(BufferDao.currentInstant())
+            .resourceType(ResourceType.GOOGLE_PROJECT)
+            .status(PoolStatus.ACTIVE)
+            .build();
+
+    Resource mockResource = Resource.builder()
+            .id(ResourceId.create(UUID.randomUUID()))
+            .poolId(oldPoolId)
+            .cloudResourceUid(cloudResourceUid)
+            .creation(BufferDao.currentInstant())
+            .state(ResourceState.HANDED_OUT)
+            .requestHandoutId(RequestHandoutId.create("test-handout-id"))
+            .build();
+
+    Mockito.when(bufferDao.retrieveResource(cloudResourceUid))
+            .thenReturn(Optional.of(mockResource));
+    Mockito.when(mockBufferDAO.retrieveLatestActivePoolByFamily("cwb_ws_prod"))
+            .thenReturn(Optional.of(newerPool));
+    Mockito.when(mockFlightScheduler.submitRepairResourceFlight(newerPool, googleProjectUid))
+            .thenReturn(Optional.of("flight-456"));
+
+    JobModel mockJobModel = new JobModel()
+            .id("flight-456")
+            .className("RepairResourceFlight")
+            .description("Repair resource for project " + projectId)
+            .jobStatus(JobModel.JobStatusEnum.RUNNING)
+            .statusCode(202);
+
+    Mockito.when(mockJobService.retrieveJob("flight-456")).thenReturn(mockJobModel);
+
+    String response = this.mvc
+            .perform(
+                    post("/api/resource/v1/" + projectId + "/repair")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+            .andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    JobModel actualJob = objectMapper.readValue(response, JobModel.class);
+    assertEquals("flight-456", actualJob.getId());
   }
 
   @Test
@@ -131,6 +188,8 @@ public class ResourceApiControllerTest {
             .build();
     Mockito.when(bufferDao.retrieveResource(cloudResourceUid))
             .thenReturn(Optional.of(resource));
+    Mockito.when(mockBufferDAO.retrieveLatestActivePoolByFamily("non-existent-pool"))
+            .thenReturn(Optional.empty());
     Mockito.when(mockBufferDAO.retrievePool(resource.poolId()))
             .thenThrow(new NotFoundException(String.format("Pool for this resource does not exist: %s.", resource.poolId())));
     this.mvc

--- a/src/test/java/bio/terra/buffer/common/PoolIdTest.java
+++ b/src/test/java/bio/terra/buffer/common/PoolIdTest.java
@@ -14,4 +14,29 @@ public class PoolIdTest extends BaseUnitTest {
     id.store(flightMap);
     assertEquals(id, PoolId.retrieve(flightMap));
   }
+
+  @Test
+  public void family_stripsVersionSuffix() {
+    assertEquals("cwb_ws_prod", PoolId.create("cwb_ws_prod_v9").family());
+  }
+
+  @Test
+  public void family_stripsLargeVersion() {
+    assertEquals("vpc_sc", PoolId.create("vpc_sc_v13").family());
+  }
+
+  @Test
+  public void family_stripsSingleDigitVersion() {
+    assertEquals("datarepo", PoolId.create("datarepo_v1").family());
+  }
+
+  @Test
+  public void family_multipleUnderscores() {
+    assertEquals("datarepo_fakeprod", PoolId.create("datarepo_fakeprod_v1").family());
+  }
+
+  @Test
+  public void family_noVersionSuffix() {
+    assertEquals("no_version_suffix", PoolId.create("no_version_suffix").family());
+  }
 }


### PR DESCRIPTION
Ticket: [RW-17225](https://precisionmedicineinitiative.atlassian.net/browse/RW-17225)
* Repairing a Google project attempts to re-enable the GCP APIs on the project that were enabled when the project was created. This will fail if any of the GCP APIs have been deprecated and removed since project creation time. Instead, we should to re-enable the current list of GCP APIs using the latest pool configuration.
* Adds the concept of a Pool family which is the Pool id without the `_v*` suffix and has the `/repair` API grab the latest active Pool from a project's Pool family as the reference point to repair the project.