### PR TITLE
PROD-1042: Upgrade to latest TCL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 dependencies {
     // Terra deps - we get Stairway via TCL
-    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.69-SNAPSHOT'
+    implementation group: 'bio.terra', name: 'terra-common-lib', version: '1.1.70-SNAPSHOT'
     implementation(group: 'bio.terra', name: 'terra-cloud-resource-lib', version: '1.2.42-SNAPSHOT') {
         exclude(group: 'com.microsoft.azure')
         exclude(group: 'com.azure')

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -130,6 +130,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
@@ -1004,12 +1005,14 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
   private void assertServiceAccountExists(Project project, String serviceAccountEmail)
       throws Exception {
     List<ServiceAccount> serviceAccounts =
-        iamCow
-            .projects()
-            .serviceAccounts()
-            .list("projects/" + project.getProjectId())
-            .execute()
-            .getAccounts();
+        Optional.ofNullable(
+                iamCow
+                    .projects()
+                    .serviceAccounts()
+                    .list("projects/" + project.getProjectId())
+                    .execute()
+                    .getAccounts())
+            .orElse(List.of());
 
     assertTrue(serviceAccounts.stream().anyMatch(s -> serviceAccountEmail.equals(s.getEmail())));
   }


### PR DESCRIPTION
RBS is currently unable to deploy because of a mismatch between the Java client k8s version and the k8s cluster version, which upgraded over the weekend. This should resolve it by pulling in a version of TCL that has the upgraded java client for k8s.