### PR TITLE
[CTM-510] update netty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,10 +130,31 @@ dependencies {
     }
 }
 
-// Force netty-codec-http to override the version pinned by Spring Boot's enforcedPlatform.
-// CVE-2026-42587 (requires >= 4.1.133.Final)
+// Force all netty artifacts to override the version pinned by Spring Boot's enforcedPlatform.
+// CVE-2026-42587 (requires >= 4.1.133.Final). All artifacts must be forced together to avoid
+// runtime errors from mixed netty versions within the suite.
 configurations.all {
-    resolutionStrategy.force 'io.netty:netty-codec-http:4.1.133.Final'
+    resolutionStrategy {
+        force 'io.netty:netty-buffer:4.1.133.Final'
+        force 'io.netty:netty-codec:4.1.133.Final'
+        force 'io.netty:netty-codec-dns:4.1.133.Final'
+        force 'io.netty:netty-codec-http:4.1.133.Final'
+        force 'io.netty:netty-codec-http2:4.1.133.Final'
+        force 'io.netty:netty-codec-socks:4.1.133.Final'
+        force 'io.netty:netty-common:4.1.133.Final'
+        force 'io.netty:netty-handler:4.1.133.Final'
+        force 'io.netty:netty-handler-proxy:4.1.133.Final'
+        force 'io.netty:netty-resolver:4.1.133.Final'
+        force 'io.netty:netty-resolver-dns:4.1.133.Final'
+        force 'io.netty:netty-resolver-dns-classes-macos:4.1.133.Final'
+        force 'io.netty:netty-resolver-dns-native-macos:4.1.133.Final'
+        force 'io.netty:netty-transport:4.1.133.Final'
+        force 'io.netty:netty-transport-classes-epoll:4.1.133.Final'
+        force 'io.netty:netty-transport-classes-kqueue:4.1.133.Final'
+        force 'io.netty:netty-transport-native-epoll:4.1.133.Final'
+        force 'io.netty:netty-transport-native-kqueue:4.1.133.Final'
+        force 'io.netty:netty-transport-native-unix-common:4.1.133.Final'
+    }
 }
 
 // for scans

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,12 @@ dependencies {
     }
 }
 
+// Force netty-codec-http to override the version pinned by Spring Boot's enforcedPlatform.
+// CVE-2026-42587 (requires >= 4.1.133.Final)
+configurations.all {
+    resolutionStrategy.force 'io.netty:netty-codec-http:4.1.133.Final'
+}
+
 // for scans
 if (hasProperty('buildScan')) {
     buildScan {

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -98,6 +98,7 @@ import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.Step;

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -98,7 +98,6 @@ import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.Step;
@@ -173,12 +172,8 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
     Pool pool = preparePool(bufferDao, newBasicGcpConfig());
 
     String flightId = manager.submitCreationFlight(pool).get();
-    FlightState flightState = blockUntilFlightComplete(stairwayComponent, flightId);
-    assertEquals(
-        FlightStatus.SUCCESS,
-        flightState.getFlightStatus(),
-        "Flight failed with exception: " + flightState.getException());
-    ResourceId resourceId = extractResourceIdFromFlightState(flightState);
+    ResourceId resourceId =
+        extractResourceIdFromFlightState(blockUntilFlightComplete(stairwayComponent, flightId));
     Project project = assertProjectExists(resourceId);
     assertBillingIs(project, pool.resourceConfig().getGcpProjectConfig().getBillingAccount());
     assertEnableApisContains(project, pool.resourceConfig().getGcpProjectConfig().getEnabledApis());

--- a/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/buffer/integration/CreateProjectFlightIntegrationTest.java
@@ -172,8 +172,12 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
     Pool pool = preparePool(bufferDao, newBasicGcpConfig());
 
     String flightId = manager.submitCreationFlight(pool).get();
-    ResourceId resourceId =
-        extractResourceIdFromFlightState(blockUntilFlightComplete(stairwayComponent, flightId));
+    FlightState flightState = blockUntilFlightComplete(stairwayComponent, flightId);
+    assertEquals(
+        FlightStatus.SUCCESS,
+        flightState.getFlightStatus(),
+        "Flight failed with exception: " + flightState.getException());
+    ResourceId resourceId = extractResourceIdFromFlightState(flightState);
     Project project = assertProjectExists(resourceId);
     assertBillingIs(project, pool.resourceConfig().getGcpProjectConfig().getBillingAccount());
     assertEnableApisContains(project, pool.resourceConfig().getGcpProjectConfig().getEnabledApis());


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-510

 Upgrades all io.netty artifacts together to 4.1.133.Final to address CVE-2026-42587, rather than just netty-codec-http alone, because Spring Boot's enforcedPlatform pins the full netty suite to 4.1.130.Final and forcing only one artifact caused runtime failures from mixed netty versions within the suite.